### PR TITLE
Moving the Cli input into new class

### DIFF
--- a/src/AbstractCliApplication.php
+++ b/src/AbstractCliApplication.php
@@ -26,6 +26,12 @@ abstract class AbstractCliApplication extends AbstractApplication
 	protected $output;
 
 	/**
+	 * @var    CliInput   Cli Input object
+	 * @since  1.2
+	 */
+	protected $cliInput;
+
+	/**
 	 * Class constructor.
 	 *
 	 * @param   Input\Cli  $input   An optional argument to provide dependency injection for the application's
@@ -60,6 +66,9 @@ abstract class AbstractCliApplication extends AbstractApplication
 		$this->set('cwd', getcwd());
 
 		$this->output = ($output instanceof CliOutput) ? $output : new Cli\Output\Stdout;
+
+		// Set the input object.
+		$this->cliInput = new Cli\CliInput;
 	}
 
 	/**
@@ -72,6 +81,18 @@ abstract class AbstractCliApplication extends AbstractApplication
 	public function getOutput()
 	{
 		return $this->output;
+	}
+
+	/**
+	 * Get an cli input object.
+	 *
+	 * @return  CliInput
+	 *
+	 * @since   1.2
+	 */
+	public function getCliInput()
+	{
+		return $this->cliInput;
 	}
 
 	/**
@@ -102,6 +123,6 @@ abstract class AbstractCliApplication extends AbstractApplication
 	 */
 	public function in()
 	{
-		return rtrim(fread(STDIN, 8192), "\n\r");
+		return $this->cliInput->in();
 	}
 }

--- a/src/Cli/CliInput.php
+++ b/src/Cli/CliInput.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Part of the Joomla Framework Application Package
+ *
+ * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Application\Cli;
+
+/**
+ * Class CliInput
+ *
+ * @since  1.2
+ */
+class CliInput
+{
+	/**
+	 * Get a value from standard input.
+	 *
+	 * @return  string  The input string from standard input.
+	 *
+	 * @codeCoverageIgnore
+	 * @since   1.2
+	 */
+	public function in()
+	{
+		return rtrim(fread(STDIN, 8192), "\n\r");
+	}
+}

--- a/src/Cli/CliInput.php
+++ b/src/Cli/CliInput.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Framework Application Package
  *
- * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 


### PR DESCRIPTION
Why?
I'm working on a console app, which uses commands as separate classes, very similar to these in [framework-status](https://github.com/mbabker/framework-status/tree/master/cli/Command) repository.

I'd like commands to have a possibility to be executed outside the `AbstractCliApplication`, anyway in my opinion commands don't not necessarily need access to whole application object. Usually it's just output, input and some objects from container.

At this moment the CLI application [input is a method](https://github.com/joomla-framework/application/blob/master/src/AbstractCliApplication.php#L103), moving into new class allows to pass it along or use own one with predefined batch of inputs.

Maybe even good for testing, but I'm not there yet.