### PR TITLE
Remove string dependancy

### DIFF
--- a/Tests/AbstractWebApplicationTest.php
+++ b/Tests/AbstractWebApplicationTest.php
@@ -966,6 +966,33 @@ class AbstractWebApplicationTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
+	 * Tests the Joomla\Application\AbstractWebApplication::redirect method.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function testIs_ascii()
+	{
+		$this->assertTrue(
+			TestHelper::invoke($this->instance, 'is_ascii', 'anormalstring9'),
+			'Regular characters should return true'
+		);
+		$this->assertFalse(
+			TestHelper::invoke($this->instance, 'is_ascii', 'anormal string9'),
+			'Spaces are not allowed in ascii'
+		);
+		$this->assertFalse(
+			TestHelper::invoke($this->instance, 'is_ascii', '@normalstrin*g9'),
+			'Symbols like @ and * are not allowed in ascii'
+		);
+		$this->assertFalse(
+			TestHelper::invoke($this->instance, 'is_ascii', 'normàlstring9'),
+			'Accented characters should return false'
+		);
+	}
+
+	/**
 	 * Tests the Joomla\Application\AbstractWebApplication::redirect method with headers already sent.
 	 *
 	 * @return  void

--- a/Tests/AbstractWebApplicationTest.php
+++ b/Tests/AbstractWebApplicationTest.php
@@ -975,7 +975,7 @@ class AbstractWebApplicationTest extends \PHPUnit_Framework_TestCase
 	public function testIs_ascii()
 	{
 		$this->assertTrue(
-			TestHelper::invoke($this->instance, 'is_ascii', 'anormalstring9'),
+			TestHelper::invoke($this->instance, 'is_ascii', 'a.normal-string_9'),
 			'Regular characters should return true'
 		);
 		$this->assertFalse(

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,6 @@
         "joomla/input": "~1.1.1",
         "joomla/event": "~1.1",
         "joomla/session": "~1.1",
-        "joomla/string": "~1.1",
         "joomla/registry": "~1.1",
         "joomla/uri": "~1.1",
         "joomla/filesystem": "~1.1",

--- a/src/AbstractWebApplication.php
+++ b/src/AbstractWebApplication.php
@@ -10,7 +10,6 @@ namespace Joomla\Application;
 
 use Joomla\Uri\Uri;
 use Joomla\Input\Input;
-use Joomla\String\String;
 use Joomla\Session\Session;
 use Joomla\Registry\Registry;
 
@@ -313,7 +312,7 @@ abstract class AbstractWebApplication extends AbstractApplication
 		else
 		{
 			// We have to use a JavaScript redirect here because MSIE doesn't play nice with utf-8 URLs.
-			if (($this->client->engine == Web\WebClient::TRIDENT) && !String::is_ascii($url))
+			if (($this->client->engine == Web\WebClient::TRIDENT) && !$this->is_ascii($url))
 			{
 				$html = '<html><head>';
 				$html .= '<meta http-equiv="content-type" content="text/html; charset=' . $this->charSet . '" />';
@@ -333,6 +332,23 @@ abstract class AbstractWebApplication extends AbstractApplication
 
 		// Close the application after the redirect.
 		$this->close();
+	}
+
+	/**
+	 * Tests whether a string contains only 7bit ASCII bytes.
+	 * You might use this to conditionally check whether a string
+	 * needs handling as UTF-8 or not, potentially offering performance
+	 * benefits by using the native PHP equivalent if it's just ASCII e.g.;
+	 *
+	 * @param   string  $str  The string to test.
+	 *
+	 * @return  boolean True if the string is all ASCII
+	 *
+	 * @since   1.0
+	 */
+	protected function is_ascii($url)
+	{
+		return (preg_match('/(?:[^\x00-\x7F])/', $str) !== 1);
 	}
 
 	/**

--- a/src/AbstractWebApplication.php
+++ b/src/AbstractWebApplication.php
@@ -346,7 +346,7 @@ abstract class AbstractWebApplication extends AbstractApplication
 	 *
 	 * @since   1.0
 	 */
-	protected function is_ascii($url)
+	private function is_ascii($str)
 	{
 		return (preg_match('/(?:[^\x00-\x7F])/', $str) !== 1);
 	}


### PR DESCRIPTION
It's quite irritating to import the entire string package for one function. So I just copied the relevant function out of string and made it a private function in the AbstractWebApplication.php where it was being used. Code duplication yes - package dependency reduction benefit greater