### PR TITLE
Deprecate session dependency

### DIFF
--- a/src/AbstractWebApplication.php
+++ b/src/AbstractWebApplication.php
@@ -66,6 +66,7 @@ abstract class AbstractWebApplication extends AbstractApplication
 	 *
 	 * @var    Session
 	 * @since  1.0
+	 * @deprecated  2.0  The joomla/session package will no longer be required by this class
 	 */
 	private $session;
 
@@ -518,6 +519,7 @@ abstract class AbstractWebApplication extends AbstractApplication
 	 * @return  Session  The session object
 	 *
 	 * @since   1.0
+	 * @deprecated  2.0  The joomla/session package will no longer be required by this class
 	 */
 	public function getSession()
 	{
@@ -642,6 +644,7 @@ abstract class AbstractWebApplication extends AbstractApplication
 	 * @return  AbstractWebApplication  Returns itself to support chaining.
 	 *
 	 * @since   1.0
+	 * @deprecated  2.0  The joomla/session package will no longer be required by this class
 	 */
 	public function setSession(Session $session)
 	{


### PR DESCRIPTION
For `Application` 2.0, we should decouple the `joomla/session` package to allow developers to inject their own session handlers.
