### PR TITLE
Remove unused joomla/controller dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,6 @@
         "psr/log": "~1.0"
     },
     "require-dev": {
-        "joomla/controller": "~1.1",
         "joomla/test": "~1.1"
     },
     "autoload": {


### PR DESCRIPTION
The `joomla/controller` package is listed as a dev requirement but unused presently.  Let's remove it for now, can always be put back if someone does use it for something.
