### PR TITLE
Create a parameter parser

### DIFF
--- a/src/Cli/Parameter.php
+++ b/src/Cli/Parameter.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Part of the Joomla Framework Application Package
+ *
+ * @copyright  Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Application\Cli;
+
+/**
+ * Class Parameter
+ *
+ * @since  1.0
+ */
+class Parameter
+{
+    /**
+     * Argumets on string format
+     *
+     * @var   array
+     * @since 1.0
+     */ 
+    private $arguments = array();
+
+    /**
+     * Constructor.
+     *
+     * @param string  $arguments
+     * @param array   $option
+     *
+     * @since 1.0
+     */ 
+    public function __construct($arguments)
+    {
+        $this->arguments = $this->fromString($arguments);
+    }
+
+    /**
+     * Verify if a parameter exists.
+     *
+     * @param string  $arguments Verify if argument has passed.
+     *
+     * @since 1.0
+     */  
+    public function has($argument)
+    {
+        return isset($this->arguments[$argument]);
+    }
+
+    /**
+     * Retrieve a value of parameter.
+     *
+     * @param string  $arguments Retrieve value for this argument.
+     *
+     * @since 1.0
+     */ 
+    public function getParameter($argument)
+    {
+        if ($this->has($argument)) {
+            return $this->arguments[$argument];
+        }
+        return false;
+    }
+
+    /**
+     * Create array with string arguments 
+     *
+     * @param   string  $string  The parameter string.
+     *
+     * @return  array   Formated and papulated with parameters information.
+     *
+     * @since   1.0
+     */
+    private function fromString($string)
+    {
+        $argumentCollection = array();
+        $parts = explode(' ', $string);
+
+        foreach ($parts as $part)
+        {
+            $subParts = explode('=', $part);
+            $argumentCollection[$subParts[0]] = isset($subParts[1]) ? trim($subParts[1], '\'"') : true; 
+        }
+        return $argumentCollection;
+    }
+}


### PR DESCRIPTION
Create a class `Joomla\Application\Cli\Parameter` to make easy work
with parameter by command line. After, we can't get paramerters passed
to our cli application by `Joomla-framework` interface. Now, if we want
this, have to instantiate a Cli\Parameter an use that.

Example:

``` php
   <?php
    use Joomla\Application\Cli;

    $inputFromUser = '--force=change -v';
    $parameters = new Cli\Parameter($inputFromUser);

    var_dump($parameters->has('--force')); // true
    var_dump($parameters->has('-n')); // false
    var_dump($parameters->getParameter('--force')); // change
    var_dump($parameters->getParameter('-v')); // 1
    var_dump($parameters->getParameter('--super-force')); // false
```

A more easy way of work with parameters.
