### PR TITLE
CLI colored output disabled on Windows by default

### DIFF
--- a/src/Cli/Output/Processor/ColorProcessor.php
+++ b/src/Cli/Output/Processor/ColorProcessor.php
@@ -53,10 +53,23 @@ class ColorProcessor implements ProcessorInterface
 	/**
 	 * Class constructor
 	 *
+	 * @param   boolean  $noColors  Defines non-colored mode on construct
+	 *
 	 * @since  1.1.0
 	 */
-	public function __construct()
+	public function __construct($noColors = null)
 	{
+		if (is_null($noColors))
+		{
+			/*
+			 * By default windows cmd.exe and PowerShell does not support ANSI-colored output
+			 * if the variable is not set explicitly colors should be disabled on Windows
+			 */
+			$noColors = (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN');
+		}
+
+		$this->noColors = $noColors;
+
 		$this->addPredefinedStyles();
 	}
 


### PR DESCRIPTION
Windows consoles does not support ANSI-colored output.
PowerShell supports write-gost command, but it is not used by PHP.
So it is better to disable colors by default on Windows platforms.

On cygwin the variable can be set explicitly, but it is a rare case.

Unfortunately, I can't emulate the situation in tests, because a predefined constant is used for OS detection.
