### PR TITLE
Miscellaneous updates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,16 +8,21 @@
     "require": {
         "php": ">=5.3.10",
         "joomla/input": "~1.2",
-        "joomla/session": "~1.1",
-        "joomla/string": "~1.1",
         "joomla/registry": "~1.1",
-        "joomla/uri": "~1.1",
         "psr/log": "~1.0"
     },
     "require-dev": {
         "joomla/test": "~1.1",
+        "joomla/session": "~1.1",
+        "joomla/string": "~1.1",
+        "joomla/uri": "~1.1",
         "phpunit/phpunit": "4.*",
         "squizlabs/php_codesniffer": "1.*"
+    },
+    "suggest": {
+        "joomla/session": "To use AbstractWebApplication with session support, install joomla/session",
+        "joomla/string": "To use AbstractWebApplication, install joomla/string",
+        "joomla/uri": "To use AbstractWebApplication, install joomla/uri"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -14,14 +14,12 @@
     "require-dev": {
         "joomla/test": "~1.1",
         "joomla/session": "~1.1",
-        "joomla/string": "~1.1",
         "joomla/uri": "~1.1",
         "phpunit/phpunit": "4.*",
         "squizlabs/php_codesniffer": "1.*"
     },
     "suggest": {
         "joomla/session": "To use AbstractWebApplication with session support, install joomla/session",
-        "joomla/string": "To use AbstractWebApplication, install joomla/string",
         "joomla/uri": "To use AbstractWebApplication, install joomla/uri"
     },
     "autoload": {

--- a/src/AbstractDaemonApplication.php
+++ b/src/AbstractDaemonApplication.php
@@ -8,7 +8,6 @@
 
 namespace Joomla\Application;
 
-use Joomla\Filesystem\Folder;
 use Joomla\Registry\Registry;
 use Joomla\Input\Cli;
 use Psr\Log\LoggerAwareInterface;

--- a/src/AbstractWebApplication.php
+++ b/src/AbstractWebApplication.php
@@ -10,7 +10,6 @@ namespace Joomla\Application;
 
 use Joomla\Uri\Uri;
 use Joomla\Input\Input;
-use Joomla\String\String;
 use Joomla\Session\Session;
 use Joomla\Registry\Registry;
 
@@ -285,7 +284,7 @@ abstract class AbstractWebApplication extends AbstractApplication
 		 */
 		if (!preg_match('#^[a-z]+\://#i', $url))
 		{
-			// Get a JURI instance for the requested URI.
+			// Get a Uri instance for the requested URI.
 			$uri = new Uri($this->get('uri.request'));
 
 			// Get a base URL to prepend from the requested URI.
@@ -314,7 +313,7 @@ abstract class AbstractWebApplication extends AbstractApplication
 		else
 		{
 			// We have to use a JavaScript redirect here because MSIE doesn't play nice with utf-8 URLs.
-			if (($this->client->engine == Web\WebClient::TRIDENT) && !String::is_ascii($url))
+			if (($this->client->engine == Web\WebClient::TRIDENT) && !$this->isAscii($url))
 			{
 				$html = '<html><head>';
 				$html .= '<meta http-equiv="content-type" content="text/html; charset=' . $this->charSet . '" />';
@@ -814,5 +813,24 @@ abstract class AbstractWebApplication extends AbstractApplication
 		$userId  = 0;
 
 		return md5($this->get('secret') . $userId . $this->getSession()->getToken($forceNew));
+	}
+
+	/**
+	 * Tests whether a string contains only 7bit ASCII bytes.
+	 *
+	 * You might use this to conditionally check whether a string
+	 * needs handling as UTF-8 or not, potentially offering performance
+	 * benefits by using the native PHP equivalent if it's just ASCII e.g.;
+	 *
+	 * @param   string  $str  The string to test.
+	 *
+	 * @return  boolean True if the string is all ASCII
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public static function isAscii($str)
+	{
+		// Search for any bytes which are outside the ASCII range...
+		return (preg_match('/(?:[^\x00-\x7F])/', $str) !== 1);
 	}
 }

--- a/src/AbstractWebApplication.php
+++ b/src/AbstractWebApplication.php
@@ -526,6 +526,11 @@ abstract class AbstractWebApplication extends AbstractApplication
 	 */
 	public function getSession()
 	{
+		if ($this->session === null)
+		{
+			throw new \RuntimeException('A \Joomla\Session\Session object has not been set.');
+		}
+
 		return $this->session;
 	}
 
@@ -776,7 +781,7 @@ abstract class AbstractWebApplication extends AbstractApplication
 
 		if (!$this->input->$method->get($token, '', 'alnum'))
 		{
-			if ($this->session->isNew())
+			if ($this->getSession()->isNew())
 			{
 				// Redirect to login screen.
 				$this->redirect('index.php');
@@ -808,6 +813,6 @@ abstract class AbstractWebApplication extends AbstractApplication
 		// @todo we need the user id somehow here
 		$userId  = 0;
 
-		return md5($this->get('secret') . $userId . $this->session->getToken($forceNew));
+		return md5($this->get('secret') . $userId . $this->getSession()->getToken($forceNew));
 	}
 }


### PR DESCRIPTION
This PR removes the hard dependency to the Session, String, and URI packages as these are only dependencies of the web application class; the CLI and base classes do not require these packages to function.

Updated references to `$this->session` in the web application class to call `getSession()` instead and have the method throw an exception if the Session object has not been set.