### PR TITLE
[codestyle] Fixed first letter casing in method names

### DIFF
--- a/Tests/AbstractWebApplicationTest.php
+++ b/Tests/AbstractWebApplicationTest.php
@@ -1507,17 +1507,17 @@ class AbstractWebApplicationTest extends \PHPUnit_Framework_TestCase
 	/**
 	 * @testdox  Tests the application correctly detects if a SSL connection is active
 	 *
-	 * @covers  Joomla\Application\AbstractWebApplication::isSSLConnection
+	 * @covers  Joomla\Application\AbstractWebApplication::isSslConnection
 	 */
-	public function testIsSSLConnection()
+	public function testisSslConnection()
 	{
 		$object = $this->getMockForAbstractClass('Joomla\Application\AbstractWebApplication');
 
-		$this->assertFalse($object->isSSLConnection());
+		$this->assertFalse($object->isSslConnection());
 
 		$object->input->server->set('HTTPS', 'on');
 
-		$this->assertTrue($object->isSSLConnection());
+		$this->assertTrue($object->isSslConnection());
 	}
 
 	/**

--- a/Tests/Web/Stubs/JWebClientInspector.php
+++ b/Tests/Web/Stubs/JWebClientInspector.php
@@ -18,9 +18,9 @@ class JWebClientInspector extends Joomla\Application\Web\WebClient
 	 *
 	 * @since   1.0
 	 */
-	public function detectRequestURI()
+	public function detectRequestUri()
 	{
-		return parent::detectRequestURI();
+		return parent::detectRequestUri();
 	}
 
 	/**
@@ -155,19 +155,19 @@ class JWebClientInspector extends Joomla\Application\Web\WebClient
 	}
 
 	/**
-	 * loadSystemURIs()
+	 * loadSystemUris()
 	 *
 	 * @return  void
 	 *
 	 * @since   1.0
 	 */
-	public function loadSystemURIs()
+	public function loadSystemUris()
 	{
-		return parent::loadSystemURIs();
+		return parent::loadSystemUris();
 	}
 
 	/**
-	 * loadSystemURIs()
+	 * loadSystemUris()
 	 *
 	 * @param   string  $ua  The user-agent string to parse.
 	 *

--- a/src/AbstractWebApplication.php
+++ b/src/AbstractWebApplication.php
@@ -573,7 +573,7 @@ abstract class AbstractWebApplication extends AbstractApplication
 	protected function detectRequestUri()
 	{
 		// First we need to detect the URI scheme.
-		if ($this->isSSLConnection())
+		if ($this->isSslConnection())
 		{
 			$scheme = 'https://';
 		}
@@ -642,7 +642,7 @@ abstract class AbstractWebApplication extends AbstractApplication
 	 *
 	 * @since   1.0
 	 */
-	public function isSSLConnection()
+	public function isSslConnection()
 	{
 		$serverSSLVar = $this->input->server->getString('HTTPS', '');
 


### PR DESCRIPTION
This PR fixes the method names to comply with the CamelCase rules mentioned here:
http://joomla.github.io/coding-standards/?coding-standards/chapters/php.md
> ...be written in CamelCase even if using traditionally uppercase acronyms (such as XML, HTML).

Not touching casing of class names as this requires changes in casing in file names and causes issues at this point.