### PR TITLE
HTTP status response not rendered correctly

### DIFF
--- a/Tests/AbstractWebApplicationTest.php
+++ b/Tests/AbstractWebApplicationTest.php
@@ -1134,7 +1134,7 @@ class AbstractWebApplicationTest extends \PHPUnit_Framework_TestCase
 			self::$headers,
 			array(
 				array('foo: bar', true, null),
-				array('Status: 200', null, 200)
+				array('HTTP/1.1 200', null, 200)
 			)
 		);
 	}

--- a/src/AbstractWebApplication.php
+++ b/src/AbstractWebApplication.php
@@ -441,7 +441,7 @@ abstract class AbstractWebApplication extends AbstractApplication
 				if ('status' == strtolower($header['name']))
 				{
 					// 'status' headers indicate an HTTP status, and need to be handled slightly differently
-					$this->header(ucfirst(strtolower($header['name'])) . ': ' . $header['value'], null, (int) $header['value']);
+					$this->header('HTTP/1.1 ' . $header['value'], null, (int) $header['value']);
 				}
 				else
 				{


### PR DESCRIPTION
As per comment, 'status' headers need to be handled slightly differently, but the code was adding a new 'status' header field rather than altering the HTTP response code.