### PR TITLE
Minor typo in examples in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ $app->setHeader('status', '401 Auhtorization required', true);
 
 Will result in response containing header
 ```
-Status Code: 401 Auhtorization required
+Status Code: 401 Authorization required
 ```
 
 ## Command Line Applications


### PR DESCRIPTION
Corrected the 401 header set in the Web Application ::setHeader() example.