### PR TITLE
Include IE11 using OEM indentifier

### DIFF
--- a/src/Web/WebClient.php
+++ b/src/Web/WebClient.php
@@ -261,6 +261,11 @@ class WebClient
 			$this->browser = self::IE;
 			$patternBrowser = 'MSIE';
 		}
+		elseif (stripos($userAgent, 'Trident') !== false)
+		{
+			$this->browser = self::IE;
+			$patternBrowser = ' rv';
+		}
 		elseif ((stripos($userAgent, 'Firefox') !== false) && (stripos($userAgent, 'like Firefox') === false))
 		{
 			$this->browser = self::FIREFOX;
@@ -291,7 +296,7 @@ class WebClient
 		if ($this->browser)
 		{
 			// Build the REGEX pattern to match the browser version string within the user agent string.
-			$pattern = '#(?<browser>Version|' . $patternBrowser . ')[/ ]+(?<version>[0-9.|a-zA-Z.]*)#';
+			$pattern = '#(?<browser>Version|' . $patternBrowser . ')[/ :]+(?<version>[0-9.|a-zA-Z.]*)#';
 
 			// Attempt to find version strings in the user agent string.
 			$matches = array();


### PR DESCRIPTION
For full user agent string: `Mozilla/5.0 (Windows NT 6.3; WOW64; Trident/7.0; LCJB; rv:11.0) like Gecko`

LCJB is in this case an OEM identifier, as described here: [https://user-agents.me/windows-oem-manufacturer-list](https://user-agents.me/windows-oem-manufacturer-list)