### PR TITLE
Add Blink engine to webclient

### DIFF
--- a/Tests/Web/WebClientTest.php
+++ b/Tests/Web/WebClientTest.php
@@ -63,6 +63,8 @@ class JApplicationWebClientTest extends PHPUnit_Framework_TestCase
 				'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_3) AppleWebKit/535.1 (KHTML, like Gecko) Chrome/13.0.782.32 Safari/535.1'),
 			array(Joomla\Application\Web\WebClient::WINDOWS, false, Joomla\Application\Web\WebClient::WEBKIT, Joomla\Application\Web\WebClient::CHROME, '12.0.742.113',
 				'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/534.30 (KHTML, like Gecko) Chrome/12.0.742.113 Safari/534.30'),
+			array(Joomla\Application\Web\WebClient::WINDOWS, false, Joomla\Application\Web\WebClient::BLINK, Joomla\Application\Web\WebClient::CHROME, '54.0.2840.71',
+				'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.71 Safari/537.36'),
 			array(Joomla\Application\Web\WebClient::LINUX, false, Joomla\Application\Web\WebClient::WEBKIT, Joomla\Application\Web\WebClient::CHROME, '12.0.742.112',
 				'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/534.30 (KHTML, like Gecko) Ubuntu/10.04 Chromium/12.0.742.112 Chrome/12.0.742.112 Safari/534.30'),
 			array(Joomla\Application\Web\WebClient::WINDOWS, false, Joomla\Application\Web\WebClient::WEBKIT, Joomla\Application\Web\WebClient::CHROME, '15.0.864.0',
@@ -170,6 +172,9 @@ class JApplicationWebClientTest extends PHPUnit_Framework_TestCase
 		return array(
 			array('Googlebot/2.1 (+http://www.google.com/bot.html)', true),
 			array('msnbot/1.0 (+http://search.msn.com/msnbot.htm)', true),
+			array('Mozilla/5.0 (compatible; Yahoo! Slurp; http://help.yahoo.com/help/us/ysearch/slurp)', true),
+			array('Mozilla/5.0 (compatible; MJ12bot/v1.4.5; http://www.majestic12.co.uk/bot.php?+)', true),
+			array('SimplePie/1.3.1 (Feed Parser; http://simplepie.org; Allow like Gecko) Build/20121030175911', true),
 			array('Mozilla/4.0 compatible ZyBorg/1.0 (wn-14.zyborg@looksmart.net; http://www.WISEnutbot.com)', true),
 			array('Mozilla/2.0 (compatible; Ask Jeeves/Teoma; +http://sp.ask.com/docs/about/tech_crawling.html)', true),
 			array('Mozilla/5.0 (iPad; U; CPU OS 3_2_1 like Mac OS X; en-us) AppleWebKit/531.21.10 (KHTML, like Gecko) Mobile/7B405', false),
@@ -178,7 +183,7 @@ class JApplicationWebClientTest extends PHPUnit_Framework_TestCase
 				  'Safari/9537.53 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)', true),
 			array('BlackBerry8300/4.2.2 Profile/MIDP-2.0 Configuration/CLDC-1.1 VendorID/107 UP.Link/6.2.3.15.02011-10-16 20:20:17', false),
 			array('IE 7 ? Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.1; .NET CLR 1.1.4322; .NET CLR 2.0.50727; .NET CLR 3.0.04506.30)2011-10-16 ' .
-				'20:20:09', false)
+				'20:20:09', false),
 		);
 	}
 

--- a/src/Web/WebClient.php
+++ b/src/Web/WebClient.php
@@ -53,6 +53,7 @@ class WebClient
 	const OPERA = 21;
 	const ANDROIDTABLET = 22;
 	const EDGE = 23;
+	const BLINK = 24;
 
 	/**
 	 * @var    integer  The detected platform on which the web client runs.
@@ -380,6 +381,10 @@ class WebClient
 		elseif (stripos($userAgent, 'Edge') !== false || stripos($userAgent, 'EdgeHTML') !== false)
 		{
 			$this->engine = self::EDGE;
+		}
+		elseif (stripos($userAgent, 'Chrome') !== false || (stripos($userAgent, 'Opera') !== false && stripos($userAgent, 'Presto') == false))
+		{
+			$this->engine = self::BLINK;
 		}
 		elseif (stripos($userAgent, 'AppleWebKit') !== false || stripos($userAgent, 'blackberry') !== false)
 		{

--- a/src/Web/WebClient.php
+++ b/src/Web/WebClient.php
@@ -420,10 +420,16 @@ class WebClient
 		}
 		elseif (stripos($userAgent, 'Opera') !== false || stripos($userAgent, 'Presto') !== false)
 		{
+			$result  = explode('/', stristr($userAgent, 'Opera'));
+			$version = explode(' ', $result[1]);
+
+			if ($version[0] >= 15)
+			{
+				$this->engine = self::BLINK;
+			}
+
 			// Sometimes Opera browsers don't say Presto.
 			$this->engine = self::PRESTO;
-
-			// $this->engine = self::BLINK;
 		}
 		elseif (stripos($userAgent, 'KHTML') !== false)
 		{

--- a/src/Web/WebClient.php
+++ b/src/Web/WebClient.php
@@ -398,19 +398,20 @@ class WebClient
 		}
 		elseif (stripos($userAgent, 'AppleWebKit') !== false || stripos($userAgent, 'blackberry') !== false)
 		{
-			$result  = explode('/', stristr($userAgent, 'AppleWebKit'));
-			$version = explode(' ', $result[1]);
+			if (stripos($userAgent, 'AppleWebKit') !== false)
+			{
+				$result  = explode('/', stristr($userAgent, 'AppleWebKit'));
+				$version = explode(' ', $result[1]);
 
-			if ($version[0] === 537.36)
-			{
-				// AppleWebKit/537.36 is Blink engine specific, exception is Blink emulated IEMobile, Trident or Edge
-				$this->engine = self::BLINK;
+				if ($version[0] === 537.36)
+				{
+					// AppleWebKit/537.36 is Blink engine specific, exception is Blink emulated IEMobile, Trident or Edge
+					$this->engine = self::BLINK;
+				}
 			}
-			else
-			{
-				// Evidently blackberry uses WebKit and doesn't necessarily report it.  Bad RIM.
-				$this->engine = self::WEBKIT;
-			}
+
+			// Evidently blackberry uses WebKit and doesn't necessarily report it.  Bad RIM.
+			$this->engine = self::WEBKIT;
 		}
 		elseif (stripos($userAgent, 'Gecko') !== false && stripos($userAgent, 'like Gecko') === false)
 		{

--- a/src/Web/WebClient.php
+++ b/src/Web/WebClient.php
@@ -385,6 +385,7 @@ class WebClient
 		elseif (stripos($userAgent, 'Chrome') !== false)
 		{
 			$result  = explode('/', stristr($this->user_agent, 'Chrome'));
+			var_dump($result);
 			$version = explode(' ', $result[1]);
 			if ($version[0] >= 28)
 			{

--- a/src/Web/WebClient.php
+++ b/src/Web/WebClient.php
@@ -398,8 +398,19 @@ class WebClient
 		}
 		elseif (stripos($userAgent, 'AppleWebKit') !== false || stripos($userAgent, 'blackberry') !== false)
 		{
-			// Evidently blackberry uses WebKit and doesn't necessarily report it.  Bad RIM.
-			$this->engine = self::WEBKIT;
+			$result  = explode('/', stristr($userAgent, 'AppleWebKit'));
+			$version = explode(' ', $result[1]);
+
+			if ($version[0] === 537.36)
+			{
+				// AppleWebKit/537.36 is Blink engine specific, exception is Blink emulated IEMobile, Trident or Edge
+				$this->engine = self::BLINK;
+			}
+			else
+			{
+				// Evidently blackberry uses WebKit and doesn't necessarily report it.  Bad RIM.
+				$this->engine = self::WEBKIT;
+			}
 		}
 		elseif (stripos($userAgent, 'Gecko') !== false && stripos($userAgent, 'like Gecko') === false)
 		{
@@ -410,7 +421,7 @@ class WebClient
 		{
 			// Sometimes Opera browsers don't say Presto.
 			$this->engine = self::PRESTO;
-			
+
 			// $this->engine = self::BLINK;
 		}
 		elseif (stripos($userAgent, 'KHTML') !== false)

--- a/src/Web/WebClient.php
+++ b/src/Web/WebClient.php
@@ -384,9 +384,9 @@ class WebClient
 		}
 		elseif (stripos($userAgent, 'Chrome') !== false)
 		{
-			$result  = explode('/', stristr($this->user_agent, 'Chrome'));
-			var_dump($result);
+			$result  = explode('/', stristr($userAgent, 'Chrome'));
 			$version = explode(' ', $result[1]);
+
 			if ($version[0] >= 28)
 			{
 				$this->engine = self::BLINK;

--- a/src/Web/WebClient.php
+++ b/src/Web/WebClient.php
@@ -382,9 +382,18 @@ class WebClient
 		{
 			$this->engine = self::EDGE;
 		}
-		elseif (stripos($userAgent, 'Chrome') !== false || (stripos($userAgent, 'Opera') !== false && stripos($userAgent, 'Presto') == false))
+		elseif (stripos($userAgent, 'Chrome') !== false)
 		{
-			$this->engine = self::BLINK;
+			$result  = explode('/', stristr($this->user_agent, 'Chrome'));
+			$version = explode(' ', $result[1]);
+			if ($version[0] >= 28)
+			{
+				$this->engine = self::BLINK;
+			}
+			else
+			{
+				$this->engine = self::WEBKIT;
+			}
 		}
 		elseif (stripos($userAgent, 'AppleWebKit') !== false || stripos($userAgent, 'blackberry') !== false)
 		{
@@ -400,6 +409,8 @@ class WebClient
 		{
 			// Sometimes Opera browsers don't say Presto.
 			$this->engine = self::PRESTO;
+			
+			// $this->engine = self::BLINK;
 		}
 		elseif (stripos($userAgent, 'KHTML') !== false)
 		{


### PR DESCRIPTION
Partial Pull Request for Issue #59 

### Summary of Changes
- Adds Blink engine to webclient
- Fixes Blink vs webkit
- Adds tests to verify chrome with blink vs chrome with webkit is detected correctly
- Adds some more common bots to the bots test to verify detection of those common bots

### Testing Instructions
Review Travis tests

### Documentation Changes Required
none