### PR TITLE
Deprecate the daemon application

### DIFF
--- a/src/AbstractDaemonApplication.php
+++ b/src/AbstractDaemonApplication.php
@@ -15,9 +15,10 @@ use Psr\Log\LoggerAwareInterface;
 /**
  * Class to turn Cli applications into daemons.  It requires CLI and PCNTL support built into PHP.
  *
- * @see    http://www.php.net/manual/en/book.pcntl.php
- * @see    http://php.net/manual/en/features.commandline.php
- * @since  1.0
+ * @see         http://www.php.net/manual/en/book.pcntl.php
+ * @see         http://php.net/manual/en/features.commandline.php
+ * @since       1.0
+ * @deprecated  2.0  Deprecated without replacement
  */
 abstract class AbstractDaemonApplication extends AbstractCliApplication implements LoggerAwareInterface
 {


### PR DESCRIPTION
### Summary of Changes

The daemon application class has never really fit in well with the Joomla API.  Additionally [most of the class has no test coverage](https://framework.joomla.org/coverage/application/AbstractDaemonApplication.php.html) and we don't really know if the class is even working at this point (it went through a round of refactoring when transitioning from Platform to Framework but to my knowledge the changes were never validated through real use or tests).  As the class is a mild black hole, I'd like to suggest deprecating it.

### Testing Instructions

N/A

### Documentation Changes Required

Note the deprecation