### PR TITLE
Add PSR-7 compatible responses

### DIFF
--- a/Tests/AbstractWebApplicationTest.php
+++ b/Tests/AbstractWebApplicationTest.php
@@ -8,6 +8,7 @@ namespace Joomla\Application\Tests;
 
 use Joomla\Application\Web\WebClient;
 use Joomla\Test\TestHelper;
+use Zend\Diactoros\Response;
 
 /**
  * Test class for Joomla\Application\AbstractWebApplication.
@@ -162,7 +163,7 @@ class AbstractWebApplicationTest extends \PHPUnit_Framework_TestCase
 			$headers[0]
 		);
 
-		$this->assertEmpty($object->getBody(true));
+		$this->assertEmpty($object->getBody());
 	}
 
 	/**
@@ -202,7 +203,7 @@ class AbstractWebApplicationTest extends \PHPUnit_Framework_TestCase
 			$headers[0]
 		);
 
-		$this->assertEmpty($object->getBody(true));
+		$this->assertEmpty($object->getBody());
 	}
 
 	/**
@@ -234,28 +235,25 @@ class AbstractWebApplicationTest extends \PHPUnit_Framework_TestCase
 			->willReturn(false);
 
 		// Mock a response.
-		$mockResponse = (object) array(
-			'cachable' => null,
-			'headers' => null,
-			'body' => array('Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
+		$response = new Response\TextResponse('Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
 				eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
 				veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
 				consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum
 				dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident,
-				sunt in culpa qui officia deserunt mollit anim id est laborum.'),
-		);
+				sunt in culpa qui officia deserunt mollit anim id est laborum.');
+		$response = $response->withoutHeader('content-type');
 
 		TestHelper::setValue(
 			$object,
 			'response',
-			$mockResponse
+			$response
 		);
 
 		TestHelper::invoke($object, 'compress');
 
 		// Ensure that the compressed body is shorter than the raw body.
 		$this->assertLessThan(
-			strlen($mockResponse->body[0]),
+			strlen($response->getBody()),
 			$object->getBody()
 		);
 
@@ -298,28 +296,25 @@ class AbstractWebApplicationTest extends \PHPUnit_Framework_TestCase
 			->willReturn(false);
 
 		// Mock a response.
-		$mockResponse = (object) array(
-			'cachable' => null,
-			'headers' => null,
-			'body' => array('Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
+		$response = new Response\TextResponse('Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
 				eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
 				veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
 				consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum
 				dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident,
-				sunt in culpa qui officia deserunt mollit anim id est laborum.'),
-		);
+				sunt in culpa qui officia deserunt mollit anim id est laborum.');
+		$response = $response->withoutHeader('content-type');
 
 		TestHelper::setValue(
 			$object,
 			'response',
-			$mockResponse
+			$response
 		);
 
 		TestHelper::invoke($object, 'compress');
 
 		// Ensure that the compressed body is shorter than the raw body.
 		$this->assertLessThan(
-			strlen($mockResponse->body[0]),
+			strlen($response->getBody()),
 			$object->getBody()
 		);
 
@@ -354,33 +349,30 @@ class AbstractWebApplicationTest extends \PHPUnit_Framework_TestCase
 		$object = $this->getMockForAbstractClass('Joomla\Application\AbstractWebApplication', array(null, null, $mockClient), '', true, true, true, array('checkHeadersSent'));
 
 		// Mock a response.
-		$mockResponse = (object) array(
-			'cachable' => null,
-			'headers' => null,
-			'body' => array(str_replace("\r\n", "\n", 'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
+		$response = new Response\TextResponse('Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
 				eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
 				veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
 				consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum
 				dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident,
-				sunt in culpa qui officia deserunt mollit anim id est laborum.')),
-		);
+				sunt in culpa qui officia deserunt mollit anim id est laborum.');
+		$response = $response->withoutHeader('content-type');
 
 		TestHelper::setValue(
 			$object,
 			'response',
-			$mockResponse
+			$response
 		);
 
 		TestHelper::invoke($object, 'compress');
 
 		// Ensure that the compressed body is shorter than the raw body.
 		$this->assertSame(
-			strlen($mockResponse->body[0]),
+			strlen($response->getBody()),
 			strlen($object->getBody())
 		);
 
 		// Ensure that no compression headers were set.
-		$this->assertNull($object->getHeaders());
+		$this->assertEmpty($object->getHeaders());
 	}
 
 	/**
@@ -409,33 +401,30 @@ class AbstractWebApplicationTest extends \PHPUnit_Framework_TestCase
 		$object = $this->getMockForAbstractClass('Joomla\Application\AbstractWebApplication', array(null, null, $mockClient));
 
 		// Mock a response.
-		$mockResponse = (object) array(
-			'cachable' => null,
-			'headers' => null,
-			'body' => array(str_replace("\r\n", "\n", 'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
+		$response = new Response\TextResponse('Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
 				eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
 				veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
 				consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum
 				dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident,
-				sunt in culpa qui officia deserunt mollit anim id est laborum.')),
-		);
+				sunt in culpa qui officia deserunt mollit anim id est laborum.');
+		$response = $response->withoutHeader('content-type');
 
 		TestHelper::setValue(
 			$object,
 			'response',
-			$mockResponse
+			$response
 		);
 
 		TestHelper::invoke($object, 'compress');
 
 		// Ensure that the compressed body is shorter than the raw body.
 		$this->assertSame(
-			strlen($mockResponse->body[0]),
+			strlen($response->getBody()),
 			strlen($object->getBody())
 		);
 
 		// Ensure that no compression headers were set.
-		$this->assertNull($object->getHeaders());
+		$this->assertEmpty($object->getHeaders());
 	}
 
 	/**
@@ -464,33 +453,30 @@ class AbstractWebApplicationTest extends \PHPUnit_Framework_TestCase
 		$object = $this->getMockForAbstractClass('Joomla\Application\AbstractWebApplication', array(null, null, $mockClient));
 
 		// Mock a response.
-		$mockResponse = (object) array(
-			'cachable' => null,
-			'headers' => null,
-			'body' => array(str_replace("\r\n", "\n", 'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
+		$response = new Response\TextResponse('Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
 				eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
 				veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
 				consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum
 				dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident,
-				sunt in culpa qui officia deserunt mollit anim id est laborum.')),
-		);
+				sunt in culpa qui officia deserunt mollit anim id est laborum.');
+		$response = $response->withoutHeader('content-type');
 
 		TestHelper::setValue(
 			$object,
 			'response',
-			$mockResponse
+			$response
 		);
 
 		TestHelper::invoke($object, 'compress');
 
 		// Ensure that the compressed body is shorter than the raw body.
 		$this->assertSame(
-			strlen($mockResponse->body[0]),
+			strlen($response->getBody()),
 			strlen($object->getBody())
 		);
 
 		// Ensure that no compression headers were set.
-		$this->assertNull($object->getHeaders());
+		$this->assertEmpty($object->getHeaders());
 	}
 
 	/**
@@ -519,7 +505,7 @@ class AbstractWebApplicationTest extends \PHPUnit_Framework_TestCase
 			$headers[0]
 		);
 
-		$this->assertEmpty($object->getBody(true));
+		$this->assertEmpty($object->getBody());
 	}
 
 	/**
@@ -552,7 +538,7 @@ class AbstractWebApplicationTest extends \PHPUnit_Framework_TestCase
 			$headers[2]
 		);
 
-		$this->assertEmpty($object->getBody(true));
+		$this->assertEmpty($object->getBody());
 	}
 
 	/**
@@ -1273,7 +1259,6 @@ class AbstractWebApplicationTest extends \PHPUnit_Framework_TestCase
 		$object = $this->getMockForAbstractClass('Joomla\Application\AbstractWebApplication');
 
 		$this->assertSame('', $object->getBody(), 'Returns an empty string by default');
-		$this->assertSame(array(), $object->getBody(true), 'Returns an empty array when requesting the body as an array');
 	}
 
 	/**

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,9 @@
         "php": "^5.5.9|~7.0",
         "joomla/input": "~1.2",
         "joomla/registry": "~2.0@dev",
-        "psr/log": "~1.0"
+        "psr/log": "~1.0",
+        "psr/http-message": "~1.0",
+        "zendframework/zend-diactoros": "~1.3"
     },
     "require-dev": {
         "joomla/test": "~1.1",

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,1 @@
+* [Updating from v1 to v2](v1-to-v2-update.md)

--- a/docs/v1-to-v2-update.md
+++ b/docs/v1-to-v2-update.md
@@ -1,0 +1,17 @@
+## Updating from v1 to v2
+
+The following changes were made to the Application package between v1 and v2.
+
+### PHP 5.3 and 5.4 support dropped
+
+The Session package now requires PHP 5.5 or newer.
+
+### PSR-7 Responses now Supported
+In order to support PSR-7 responses there is a single break in backwards incompatibility.
+The `\Joomla\Application\AbstractWebApplication::getBody()` method does not have a
+`toBody` parameter. Joomla will default to use Zend Framework's Diactoros package
+ if none is provided.
+ 
+ If you wish to provide another package's response object then simply inject it into the
+ constructor of `\Joomla\Application\AbstractWebApplication`
+

--- a/src/AbstractWebApplication.php
+++ b/src/AbstractWebApplication.php
@@ -76,7 +76,7 @@ abstract class AbstractWebApplication extends AbstractApplication
 	 * Is caching enabled?
 	 *
 	 * @var    boolean
-	 * @since  1.0
+	 * @since  __DEPLOY_VERSION__
 	 */
 	private $cacheable = false;
 

--- a/src/AbstractWebApplication.php
+++ b/src/AbstractWebApplication.php
@@ -12,6 +12,8 @@ use Joomla\Input\Input;
 use Joomla\Registry\Registry;
 use Joomla\Session\SessionInterface;
 use Joomla\Uri\Uri;
+use Psr\Http\Message\ResponseInterface;
+use Zend\Diactoros\Stream;
 
 /**
  * Base class for a Joomla! Web application.
@@ -55,7 +57,7 @@ abstract class AbstractWebApplication extends AbstractApplication
 	/**
 	 * The application response object.
 	 *
-	 * @var    object
+	 * @var    ResponseInterface
 	 * @since  1.0
 	 */
 	protected $response;
@@ -67,6 +69,14 @@ abstract class AbstractWebApplication extends AbstractApplication
 	 * @since  1.0
 	 */
 	private $session;
+
+	/**
+	 * Is caching enabled?
+	 *
+	 * @var    boolean
+	 * @since  1.0
+	 */
+	private $cacheable = false;
 
 	/**
 	 * A map of integer HTTP 1.1 response codes to the full HTTP Status for the headers.
@@ -90,27 +100,31 @@ abstract class AbstractWebApplication extends AbstractApplication
 	/**
 	 * Class constructor.
 	 *
-	 * @param   Input          $input   An optional argument to provide dependency injection for the application's input object.  If the argument
-	 *                                  is an Input object that object will become the application's input object, otherwise a default input
-	 *                                  object is created.
-	 * @param   Registry       $config  An optional argument to provide dependency injection for the application's config object.  If the argument
-	 *                                  is a Registry object that object will become the application's config object, otherwise a default config
-	 *                                  object is created.
-	 * @param   Web\WebClient  $client  An optional argument to provide dependency injection for the application's client object.  If the argument
-	 *                                  is a Web\WebClient object that object will become the application's client object, otherwise a default client
-	 *                                  object is created.
+	 * @param   ResponseInterface  $response  An optional argument to provide dependency injection for the application's
+	 *                                        input object.  If the argument is an Input object that object will become
+	 *                                        the application's input object, otherwise a default input object is
+	 *                                        created.
+	 * @param   Input              $input     An optional argument to provide dependency injection for the application's
+	 *                                        input object.  If the argument is an Input object that object will become
+	 *                                        the application's input object, otherwise a default input object is
+	 *                                        created.
+	 * @param   Registry           $config    An optional argument to provide dependency injection for the application's
+	 *                                        config object.  If the argument is a Registry object that object will
+	 *                                        become the application's config object, otherwise a default config object
+	 *                                        is created.
+	 * @param   Web\WebClient      $client    An optional argument to provide dependency injection for the application's
+	 *                                        client object.  If the argument is a Web\WebClient object that object will
+	 *                                        become the application's client object, otherwise a default client object
+	 *                                        is created.
 	 *
 	 * @since   1.0
 	 */
-	public function __construct(Input $input = null, Registry $config = null, Web\WebClient $client = null)
+	public function __construct(ResponseInterface $response, Input $input = null, Registry $config = null, Web\WebClient $client = null)
 	{
 		$this->client = $client ?: new Web\WebClient;
 
 		// Setup the response object.
-		$this->response           = new \stdClass;
-		$this->response->cachable = false;
-		$this->response->headers  = [];
-		$this->response->body     = [];
+		$this->setResponse($response);
 
 		// Call the constructor as late as possible (it runs `initialise`).
 		parent::__construct($input, $config);
@@ -374,10 +388,10 @@ abstract class AbstractWebApplication extends AbstractApplication
 	{
 		if ($allow !== null)
 		{
-			$this->response->cachable = (bool) $allow;
+			$this->cacheable = (bool) $allow;
 		}
 
-		return $this->response->cachable;
+		return $this->cacheable;
 	}
 
 	/**
@@ -397,26 +411,18 @@ abstract class AbstractWebApplication extends AbstractApplication
 	public function setHeader($name, $value, $replace = false)
 	{
 		// Sanitize the input values.
-		$name  = (string) $name;
-		$value = (string) $value;
+		$name     = (string) $name;
+		$value    = (string) $value;
+		$response = $this->getResponse();
 
 		// If the replace flag is set, unset all known headers with the given name.
-		if ($replace)
+		if ($replace && $response->hasHeader($name))
 		{
-			foreach ($this->response->headers as $key => $header)
-			{
-				if ($name == $header['name'])
-				{
-					unset($this->response->headers[$key]);
-				}
-			}
-
-			// Clean up the array as unsetting nested arrays leaves some junk.
-			$this->response->headers = array_values($this->response->headers);
+			$response->withoutHeader($name);
 		}
 
 		// Add the header to the internal array.
-		$this->response->headers[] = ['name' => $name, 'value' => $value];
+		$this->setResponse($response->withAddedHeader($name, $value));
 
 		return $this;
 	}
@@ -430,7 +436,7 @@ abstract class AbstractWebApplication extends AbstractApplication
 	 */
 	public function getHeaders()
 	{
-		return $this->response->headers;
+		return $this->getResponse()->getHeaders();
 	}
 
 	/**
@@ -442,7 +448,14 @@ abstract class AbstractWebApplication extends AbstractApplication
 	 */
 	public function clearHeaders()
 	{
-		$this->response->headers = [];
+		$response = $this->getResponse();
+
+		foreach ($response->getHeaders() as $name => $values)
+		{
+			$response = $response->withoutHeader($name);
+		}
+
+		$this->setResponse($response);
 
 		return $this;
 	}
@@ -458,7 +471,7 @@ abstract class AbstractWebApplication extends AbstractApplication
 	{
 		if (!$this->checkHeadersSent())
 		{
-			foreach ($this->response->headers as $header)
+			foreach ($this->getResponse()->getHeaders() as $header)
 			{
 				if ('status' == strtolower($header['name']))
 				{
@@ -486,7 +499,9 @@ abstract class AbstractWebApplication extends AbstractApplication
 	 */
 	public function setBody($content)
 	{
-		$this->response->body = [(string) $content];
+		$stream = new Stream('php://memory', 'rw');
+		$stream->write((string) $content);
+		$this->setResponse($this->getResponse()->withBody($stream));
 
 		return $this;
 	}
@@ -502,7 +517,10 @@ abstract class AbstractWebApplication extends AbstractApplication
 	 */
 	public function prependBody($content)
 	{
-		array_unshift($this->response->body, (string) $content);
+		$currentBody = $this->getBody();
+		$stream = new Stream('php://memory', 'rw');
+		$stream->write((string) $content . $currentBody);
+		$this->setResponse($this->getResponse()->withBody($stream));
 
 		return $this;
 	}
@@ -518,7 +536,10 @@ abstract class AbstractWebApplication extends AbstractApplication
 	 */
 	public function appendBody($content)
 	{
-		array_push($this->response->body, (string) $content);
+		$currentBody = $this->getBody();
+		$stream = new Stream('php://memory', 'rw');
+		$stream->write($currentBody . (string) $content);
+		$this->setResponse($this->getResponse()->withBody($stream));
 
 		return $this;
 	}
@@ -526,15 +547,25 @@ abstract class AbstractWebApplication extends AbstractApplication
 	/**
 	 * Return the body content
 	 *
-	 * @param   boolean  $asArray  True to return the body as an array of strings.
-	 *
-	 * @return  mixed  The response body either as an array or concatenated string.
+	 * @return  mixed  The response body as a string.
 	 *
 	 * @since   1.0
 	 */
-	public function getBody($asArray = false)
+	public function getBody()
 	{
-		return $asArray ? $this->response->body : implode((array) $this->response->body);
+		return (string) $this->getResponse()->getBody();
+	}
+
+	/**
+	 * Get the PSR-7 Response Object.
+	 *
+	 * @return  ResponseInterface
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getResponse()
+	{
+		return $this->response;
 	}
 
 	/**
@@ -644,6 +675,20 @@ abstract class AbstractWebApplication extends AbstractApplication
 	protected function header($string, $replace = true, $code = null)
 	{
 		header(str_replace(chr(0), '', $string), $replace, $code);
+	}
+
+	/**
+	 * Set the PSR-7 Response Object.
+	 *
+	 * @param   ResponseInterface  $response  The response object
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function setResponse(ResponseInterface $response)
+	{
+		$this->response = $response;
 	}
 
 	/**

--- a/src/AbstractWebApplication.php
+++ b/src/AbstractWebApplication.php
@@ -436,7 +436,7 @@ abstract class AbstractWebApplication extends AbstractApplication
 	/**
 	 * Method to get the array of response headers to be sent when the response is sent to the client.
 	 *
-	 * @return  array|null
+	 * @return  array
 	 *
 	 * @since   1.0
 	 */

--- a/src/AbstractWebApplication.php
+++ b/src/AbstractWebApplication.php
@@ -13,6 +13,7 @@ use Joomla\Registry\Registry;
 use Joomla\Session\SessionInterface;
 use Joomla\Uri\Uri;
 use Psr\Http\Message\ResponseInterface;
+use Zend\Diactoros\Response;
 use Zend\Diactoros\Stream;
 
 /**
@@ -100,10 +101,6 @@ abstract class AbstractWebApplication extends AbstractApplication
 	/**
 	 * Class constructor.
 	 *
-	 * @param   ResponseInterface  $response  An optional argument to provide dependency injection for the application's
-	 *                                        input object.  If the argument is an Input object that object will become
-	 *                                        the application's input object, otherwise a default input object is
-	 *                                        created.
 	 * @param   Input              $input     An optional argument to provide dependency injection for the application's
 	 *                                        input object.  If the argument is an Input object that object will become
 	 *                                        the application's input object, otherwise a default input object is
@@ -116,14 +113,23 @@ abstract class AbstractWebApplication extends AbstractApplication
 	 *                                        client object.  If the argument is a Web\WebClient object that object will
 	 *                                        become the application's client object, otherwise a default client object
 	 *                                        is created.
+	 * @param   ResponseInterface  $response  An optional argument to provide dependency injection for the application's
+	 *                                        input object.  If the argument is an Input object that object will become
+	 *                                        the application's input object, otherwise a default input object is
+	 *                                        created.
 	 *
 	 * @since   1.0
 	 */
-	public function __construct(ResponseInterface $response, Input $input = null, Registry $config = null, Web\WebClient $client = null)
+	public function __construct(Input $input = null, Registry $config = null, Web\WebClient $client = null, ResponseInterface $response = null)
 	{
 		$this->client = $client ?: new Web\WebClient;
 
 		// Setup the response object.
+		if (!$response)
+		{
+			$response = new Response;
+		}
+
 		$this->setResponse($response);
 
 		// Call the constructor as late as possible (it runs `initialise`).

--- a/src/AbstractWebApplication.php
+++ b/src/AbstractWebApplication.php
@@ -424,7 +424,7 @@ abstract class AbstractWebApplication extends AbstractApplication
 		// If the replace flag is set, unset all known headers with the given name.
 		if ($replace && $response->hasHeader($name))
 		{
-			$response->withoutHeader($name);
+			$response = $response->withoutHeader($name);
 		}
 
 		// Add the header to the internal array.
@@ -436,13 +436,23 @@ abstract class AbstractWebApplication extends AbstractApplication
 	/**
 	 * Method to get the array of response headers to be sent when the response is sent to the client.
 	 *
-	 * @return  array
+	 * @return  array|null
 	 *
 	 * @since   1.0
 	 */
 	public function getHeaders()
 	{
-		return $this->getResponse()->getHeaders();
+		$return = [];
+
+		foreach ($this->getResponse()->getHeaders() as $name => $values)
+		{
+			foreach ($values as $value)
+			{
+				$return[] = ['name' => $name, 'value' => $value];
+			}
+		}
+
+		return $return;
 	}
 
 	/**
@@ -477,7 +487,7 @@ abstract class AbstractWebApplication extends AbstractApplication
 	{
 		if (!$this->checkHeadersSent())
 		{
-			foreach ($this->getResponse()->getHeaders() as $header)
+			foreach ($this->getHeaders() as $header)
 			{
 				if ('status' == strtolower($header['name']))
 				{

--- a/src/Exception/UnableToWriteBody.php
+++ b/src/Exception/UnableToWriteBody.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Part of the Joomla Framework Application Package
+ *
+ * @copyright  Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Application\Exception;
+
+class UnableToWriteBody extends \DomainException
+{
+	/**
+	 * Constructor.
+	 *
+	 * @param   string      $message   The Exception message to throw.
+	 * @param   int         $code      The Exception code.
+	 * @param   \Exception  $previous  The previous exception used for the exception chaining.
+	 *
+	 * @since   2.0.0
+	 */
+	public function __construct($message = '', $code = 500, \Exception $previous = null)
+	{
+	}
+}

--- a/src/Exception/UnableToWriteBody.php
+++ b/src/Exception/UnableToWriteBody.php
@@ -8,6 +8,11 @@
 
 namespace Joomla\Application\Exception;
 
+/**
+ * Exception thrown when the application can't write to the response body
+ *
+ * @since  __DEPLOY_VERSION__
+ */
 class UnableToWriteBody extends \DomainException
 {
 	/**


### PR DESCRIPTION
### Summary of Changes
This adds PSR-7 compatible responses to our Application layer.

There is one b/c breaking change - getBody no longer accepts toArray as a parameter as it stored in a stream object now rather than as an array of strings

### Documentation Changes Required
