### PR TITLE
Make getFormToken an abstract method

### DIFF
--- a/Tests/AbstractWebApplicationTest.php
+++ b/Tests/AbstractWebApplicationTest.php
@@ -1599,30 +1599,6 @@ class AbstractWebApplicationTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * @testdox  Tests the application correctly retrieves a form token
-	 *
-	 * @covers  Joomla\Application\AbstractWebApplication::getFormToken
-	 * @uses    Joomla\Application\AbstractApplication::set
-	 * @uses    Joomla\Application\AbstractWebApplication::setSession
-	 */
-	public function testGetFormToken()
-	{
-		$object = $this->getMockForAbstractClass('Joomla\Application\AbstractWebApplication');
-		$mockSession = $this->getMockBuilder('Joomla\Session\Session')
-			->disableOriginalConstructor()
-			->getMock();
-
-		$object->setSession($mockSession);
-		$object->set('secret', 'abc');
-		$expected = md5('abc' . 0 . $object->getSession()->getToken());
-
-		$this->assertSame(
-			$expected,
-			$object->getFormToken()
-		);
-	}
-
-	/**
 	 * {@inheritdoc}
 	 */
 	protected function tearDown()

--- a/Tests/Stubs/ConcreteWeb.php
+++ b/Tests/Stubs/ConcreteWeb.php
@@ -122,4 +122,20 @@ class ConcreteWeb extends AbstractWebApplication
 	{
 		$this->headers[] = array($string, $replace, $code);
 	}
+
+	/**
+	 * Method to determine a hash for anti-spoofing variable names
+	 *
+	 * @param   boolean  $forceNew  If true, force a new token to be created
+	 *
+	 * @return  string  Hashed var name
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getFormToken($forceNew = false)
+	{
+		$userId  = 0;
+
+		return md5($this->get('secret') . $userId . $this->getSession()->getToken($forceNew));
+	}
 }

--- a/src/AbstractWebApplication.php
+++ b/src/AbstractWebApplication.php
@@ -814,13 +814,7 @@ abstract class AbstractWebApplication extends AbstractApplication
 	 *
 	 * @since   1.0
 	 */
-	public function getFormToken($forceNew = false)
-	{
-		// @todo we need the user id somehow here
-		$userId  = 0;
-
-		return md5($this->get('secret') . $userId . $this->getSession()->getToken($forceNew));
-	}
+	abstract public function getFormToken($forceNew = false);
 
 	/**
 	 * Tests whether a string contains only 7bit ASCII bytes.


### PR DESCRIPTION
Generating a form token is application specific. So let's make this method abstract and stop trying to come up with dozens of framework specific ways to build a session token.

If people are happy with this then I'll add it to the docs