### PR TITLE
Allow Content-Type, Last-Modified, and Expires headers to be set in the Response object

### DIFF
--- a/src/AbstractWebApplication.php
+++ b/src/AbstractWebApplication.php
@@ -251,7 +251,10 @@ abstract class AbstractWebApplication extends AbstractApplication
 	protected function respond()
 	{
 		// Send the content-type header.
-		$this->setHeader('Content-Type', $this->mimeType . '; charset=' . $this->charSet);
+		if (!$this->getResponse()->hasHeader('Content-Type'))
+		{
+			$this->setHeader('Content-Type', $this->mimeType . '; charset=' . $this->charSet);
+		}
 
 		// If the response is set to uncachable, we need to set some appropriate headers so browsers don't cache the response.
 		if (!$this->allowCache())
@@ -269,10 +272,13 @@ abstract class AbstractWebApplication extends AbstractApplication
 		else
 		{
 			// Expires.
-			$this->setHeader('Expires', gmdate('D, d M Y H:i:s', time() + 900) . ' GMT');
+			if (!$this->getResponse()->hasHeader('Expires'))
+			{
+				$this->setHeader('Expires', gmdate('D, d M Y H:i:s', time() + 900) . ' GMT');
+			}
 
 			// Last modified.
-			if ($this->modifiedDate instanceof \DateTime)
+			if (!$this->getResponse()->hasHeader('Last-Modified') && $this->modifiedDate instanceof \DateTime)
 			{
 				$this->modifiedDate->setTimezone(new \DateTimeZone('UTC'));
 				$this->setHeader('Last-Modified', $this->modifiedDate->format('D, d M Y H:i:s') . ' GMT');


### PR DESCRIPTION
Allow devs who set a full `Psr\Http\Message\ResponseInterface` object to the application to set the `Content-Type` header within the object as well as the `Last-Modified` and `Expires` headers when the application is set to allow cached responses.  If the headers are already set in the response object, we won't overwrite these values when sending the response, otherwise it should be business as usual.

I purposely didn't touch the no caching route as that is setting some sensible default values for now.