### PR TITLE
Use `@link` over `@see` and move PHP Links to https && wrong return types

### DIFF
--- a/Tests/Stubs/ConcreteDaemon.php
+++ b/Tests/Stubs/ConcreteDaemon.php
@@ -78,7 +78,7 @@ class ConcreteDaemon extends AbstractDaemonApplication
 	 *
 	 * @param   mixed  $value  The value of the property.
 	 *
-	 * @return  void.
+	 * @return  void
 	 *
 	 * @since   1.0
 	 */
@@ -93,7 +93,7 @@ class ConcreteDaemon extends AbstractDaemonApplication
 	 * @param   string  $name   The name of the property.
 	 * @param   mixed   $value  The value of the property.
 	 *
-	 * @return  void.
+	 * @return  void
 	 *
 	 * @since   1.0
 	 * @throws  \Exception

--- a/src/AbstractDaemonApplication.php
+++ b/src/AbstractDaemonApplication.php
@@ -15,8 +15,8 @@ use Psr\Log\LoggerAwareInterface;
 /**
  * Class to turn Cli applications into daemons.  It requires CLI and PCNTL support built into PHP.
  *
- * @see         http://www.php.net/manual/en/book.pcntl.php
- * @see         http://php.net/manual/en/features.commandline.php
+ * @link        https://secure.php.net/manual/en/book.pcntl.php
+ * @link        https://secure.php.net/manual/en/features.commandline.php
  * @since       1.0
  * @deprecated  2.0  Deprecated without replacement
  */
@@ -24,7 +24,7 @@ abstract class AbstractDaemonApplication extends AbstractCliApplication implemen
 {
 	/**
 	 * @var    array  The available POSIX signals to be caught by default.
-	 * @see    http://php.net/manual/pcntl.constants.php
+	 * @link   https://secure.php.net/manual/pcntl.constants.php
 	 * @since  1.0
 	 */
 	protected static $signals = array(

--- a/src/AbstractWebApplication.php
+++ b/src/AbstractWebApplication.php
@@ -73,7 +73,7 @@ abstract class AbstractWebApplication extends AbstractApplication
 	 *
 	 * @var    array
 	 * @since  1.6.0
-	 * @see    https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
+	 * @link   https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
 	 */
 	private $responseMap = array(
 		300 => 'HTTP/1.1 300 Multiple Choices',


### PR DESCRIPTION
### Summary of Changes

Use `@link` over `@see` and move PHP Links to https && wrong return types

### Testing Instructions

Review

### Documentation Changes Required

None