### PR TITLE
Port fixes to the redirect method from the CMS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ vendor/
 composer.phar
 composer.lock
 phpunit.xml
+.idea/

--- a/src/AbstractWebApplication.php
+++ b/src/AbstractWebApplication.php
@@ -76,6 +76,19 @@ abstract class AbstractWebApplication extends AbstractApplication
 	 * @link   https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
 	 */
 	private $responseMap = array(
+		100 => 'HTTP/1.1 100 Continue',
+		101 => 'HTTP/1.1 101 Switching Protocols',
+		102 => 'HTTP/1.1 102 Processing',
+		200 => 'HTTP/1.1 200 OK',
+		201 => 'HTTP/1.1 201 Created',
+		202 => 'HTTP/1.1 202 Accepted',
+		203 => 'HTTP/1.1 203 Non-Authoritative Information',
+		204 => 'HTTP/1.1 204 No Content',
+		205 => 'HTTP/1.1 205 Reset Content',
+		206 => 'HTTP/1.1 206 Partial Content',
+		207 => 'HTTP/1.1 207 Multi-Status',
+		208 => 'HTTP/1.1 208 Already Reported',
+		226 => 'HTTP/1.1 226 IM Used',
 		300 => 'HTTP/1.1 300 Multiple Choices',
 		301 => 'HTTP/1.1 301 Moved Permanently',
 		302 => 'HTTP/1.1 302 Found',
@@ -84,7 +97,46 @@ abstract class AbstractWebApplication extends AbstractApplication
 		305 => 'HTTP/1.1 305 Use Proxy',
 		306 => 'HTTP/1.1 306 (Unused)',
 		307 => 'HTTP/1.1 307 Temporary Redirect',
-		308 => 'HTTP/1.1 308 Permanent Redirect'
+		308 => 'HTTP/1.1 308 Permanent Redirect',
+		400 => 'HTTP/1.1 400 Bad Request',
+		401 => 'HTTP/1.1 401 Unauthorized',
+		402 => 'HTTP/1.1 402 Payment Required',
+		403 => 'HTTP/1.1 403 Forbidden',
+		404 => 'HTTP/1.1 404 Not Found',
+		405 => 'HTTP/1.1 405 Method Not Allowed',
+		406 => 'HTTP/1.1 406 Not Acceptable',
+		407 => 'HTTP/1.1 407 Proxy Authentication Required',
+		408 => 'HTTP/1.1 408 Request Timeout',
+		409 => 'HTTP/1.1 409 Conflict',
+		410 => 'HTTP/1.1 410 Gone',
+		411 => 'HTTP/1.1 411 Length Required',
+		412 => 'HTTP/1.1 412 Precondition Failed',
+		413 => 'HTTP/1.1 413 Payload Too Large',
+		414 => 'HTTP/1.1 414 URI Too Long',
+		415 => 'HTTP/1.1 415 Unsupported Media Type',
+		416 => 'HTTP/1.1 416 Range Not Satisfiable',
+		417 => 'HTTP/1.1 417 Expectation Failed',
+		418 => 'HTTP/1.1 418 I\'m a teapot',
+		421 => 'HTTP/1.1 421 Misdirected Request',
+		422 => 'HTTP/1.1 422 Unprocessable Entity',
+		423 => 'HTTP/1.1 423 Locked',
+		424 => 'HTTP/1.1 424 Failed Dependency',
+		426 => 'HTTP/1.1 426 Upgrade Required',
+		428 => 'HTTP/1.1 428 Precondition Required',
+		429 => 'HTTP/1.1 429 Too Many Requests',
+		431 => 'HTTP/1.1 431 Request Header Fields Too Large',
+		451 => 'HTTP/1.1 451 Unavailable For Legal Reasons',
+		500 => 'HTTP/1.1 500 Internal Server Error',
+		501 => 'HTTP/1.1 501 Not Implemented',
+		502 => 'HTTP/1.1 502 Bad Gateway',
+		503 => 'HTTP/1.1 503 Service Unavailable',
+		504 => 'HTTP/1.1 504 Gateway Timeout',
+		505 => 'HTTP/1.1 505 HTTP Version Not Supported',
+		506 => 'HTTP/1.1 506 Variant Also Negotiates',
+		507 => 'HTTP/1.1 507 Insufficient Storage',
+		508 => 'HTTP/1.1 508 Loop Detected',
+		510 => 'HTTP/1.1 510 Not Extended',
+		511 => 'HTTP/1.1 511 Network Authentication Required',
 	);
 
 	/**
@@ -346,20 +398,19 @@ abstract class AbstractWebApplication extends AbstractApplication
 					$status = $status ? 301 : 303;
 				}
 
-				if (!is_int($status) && !isset($this->responseMap[$status]))
+				if (!is_int($status) && !$this->isRedirectState($status))
 				{
 					throw new \InvalidArgumentException('You have not supplied a valid HTTP 1.1 status code');
 				}
 
 				// All other cases use the more efficient HTTP header for redirection.
-				$this->header($this->responseMap[$status]);
-				$this->header('Location: ' . $url);
-				$this->header('Content-Type: text/html; charset=' . $this->charSet);
-
-				// Send other headers that may have been set.
-				$this->sendHeaders();
+				$this->setHeader('Status', $status, true);
+				$this->setHeader('Location', $url, true);
 			}
 		}
+
+		// Set appropriate headers
+		$this->respond();
 
 		// Close the application after the redirect.
 		$this->close();
@@ -468,7 +519,9 @@ abstract class AbstractWebApplication extends AbstractApplication
 				if ('status' == strtolower($header['name']))
 				{
 					// 'status' headers indicate an HTTP status, and need to be handled slightly differently
-					$this->header('HTTP/1.1 ' . $header['value'], null, (int) $header['value']);
+					$status = $this->getHttpStatusValue($header['value']);
+
+					$this->header($status, true, (int) $header['value']);
 				}
 				else
 				{
@@ -557,6 +610,27 @@ abstract class AbstractWebApplication extends AbstractApplication
 		}
 
 		return $this->session;
+	}
+
+	/**
+	 * Check if a given value can be successfully mapped to a valid http status value
+	 *
+	 * @param   string  $value  The given status as int or string
+	 *
+	 * @return string
+	 *
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected function getHttpStatusValue($value)
+	{
+		$code = (int) $value;
+
+		if (array_key_exists($code, $this->responseMap))
+		{
+			return $this->responseMap[$code];
+		}
+
+		return 'HTTP/1.1 ' . $code;
 	}
 
 	/**
@@ -659,6 +733,22 @@ abstract class AbstractWebApplication extends AbstractApplication
 	protected function header($string, $replace = true, $code = null)
 	{
 		header(str_replace(chr(0), '', $string), $replace, $code);
+	}
+
+	/**
+	 * Checks if a state is a redirect state
+	 *
+	 * @param   integer  $state  The HTTP 1.1 status code.
+	 *
+	 * @return  bool
+	 *
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected function isRedirectState($state)
+	{
+		$state = (int) $state;
+
+		return ($state > 299 && $state < 400 && array_key_exists($state, $this->responseMap));
 	}
 
 	/**


### PR DESCRIPTION
### Summary of Changes
Ports https://github.com/joomla/joomla-cms/pull/13516 , https://github.com/joomla/joomla-cms/pull/15738 and https://github.com/joomla/joomla-cms/pull/16040 which fix cases where caching was incorrectly applied to redirect methods

This also ensure that our status codes are fully output correctly

### Testing Instructions
Ensure redirects continue to work and the correct status code is used

### Documentation Changes Required
None
