### PR TITLE
Add method to check an integer is a valid HTTP Status Code

### DIFF
--- a/Tests/AbstractWebApplicationTest.php
+++ b/Tests/AbstractWebApplicationTest.php
@@ -1731,6 +1731,34 @@ class AbstractWebApplicationTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
+	 * @testdox  Tests the application correctly approves a valid HTTP Status Code
+	 *
+	 * @covers  Joomla\Application\AbstractWebApplication::isValidHttpStatus
+	 */
+	public function testGetHttpStatusValue()
+	{
+		$object = $this->getMockForAbstractClass('Joomla\Application\AbstractWebApplication');
+
+		$this->assertTrue(
+			$object->isValidHttpStatus(500)
+		);
+	}
+
+	/**
+	 * @testdox  Tests the application correctly rejects a valid HTTP Status Code
+	 *
+	 * @covers  Joomla\Application\AbstractWebApplication::isValidHttpStatus
+	 */
+	public function testInvalidHttpStatusValue()
+	{
+		$object = $this->getMockForAbstractClass('Joomla\Application\AbstractWebApplication');
+
+		$this->assertFalse(
+			$object->isValidHttpStatus(460)
+		);
+	}
+
+	/**
 	 * {@inheritdoc}
 	 */
 	protected function tearDown()

--- a/src/AbstractWebApplication.php
+++ b/src/AbstractWebApplication.php
@@ -615,7 +615,7 @@ abstract class AbstractWebApplication extends AbstractApplication
 	/**
 	 * Check if a given value can be successfully mapped to a valid http status value
 	 *
-	 * @param   string  $value  The given status as int or string
+	 * @param   string|int  $value  The given status as int or string
 	 *
 	 * @return string
 	 *
@@ -631,6 +631,20 @@ abstract class AbstractWebApplication extends AbstractApplication
 		}
 
 		return 'HTTP/1.1 ' . $code;
+	}
+
+	/**
+	 * Check if the value is a valid HTTP 1.1 status code
+	 *
+	 * @param   int  $code  The potential status code
+	 *
+	 * @return  bool
+	 *
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public function isValidHttpStatus($code)
+	{
+		return array_key_exists($code, $this->responseMap);
 	}
 
 	/**


### PR DESCRIPTION
Allows checking you have a valid HTTP Status code. Can be useful when doing things like checking the code associated with exceptions in the App