### PR TITLE
[2.0] Event support restored

### DIFF
--- a/Tests/AbstractApplicationTest.php
+++ b/Tests/AbstractApplicationTest.php
@@ -80,6 +80,27 @@ class AbstractApplicationTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
+	 * @testdox  Tests that the application is executed successfully when an event dispatcher is registered.
+	 *
+	 * @covers  Joomla\Application\AbstractApplication::execute
+	 */
+	public function testExecuteWithEvents()
+	{
+		$dispatcher = $this->getMockBuilder('Joomla\Event\DispatcherInterface')->getMock();
+		$dispatcher->expects($this->exactly(2))
+			->method('dispatch');
+
+		$object = $this->getMockForAbstractClass('Joomla\Application\AbstractApplication');
+		$object->expects($this->once())
+			->method('doExecute');
+
+		$object->setDispatcher($dispatcher);
+
+		// execute() has no return, with our mock nothing should happen but ensuring that the mock's doExecute() stub is triggered
+		$this->assertNull($object->execute());
+	}
+
+	/**
 	 * @testdox  Tests that data is read from the application configuration successfully.
 	 *
 	 * @covers  Joomla\Application\AbstractApplication::get

--- a/Tests/AbstractWebApplicationTest.php
+++ b/Tests/AbstractWebApplicationTest.php
@@ -167,6 +167,44 @@ class AbstractWebApplicationTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
+	 * @testdox  Tests that the application is executed successfully when an event dispatcher is registered.
+	 *
+	 * @covers  Joomla\Application\AbstractWebApplication::execute
+	 * @uses    Joomla\Application\AbstractWebApplication::allowCache
+	 * @uses    Joomla\Application\AbstractWebApplication::getBody
+	 * @uses    Joomla\Application\AbstractWebApplication::getHeaders
+	 */
+	public function testExecuteWithEvents()
+	{
+		$dispatcher = $this->getMockBuilder('Joomla\Event\DispatcherInterface')->getMock();
+		$dispatcher->expects($this->exactly(4))
+			->method('dispatch');
+
+		$object = $this->getMockForAbstractClass('Joomla\Application\AbstractWebApplication');
+		$object->expects($this->once())
+			->method('doExecute');
+
+		$object->setDispatcher($dispatcher);
+
+		// execute() has no return, with our mock nothing should happen but ensuring that the mock's doExecute() stub is triggered
+		$this->assertNull($object->execute());
+
+		$this->assertFalse($object->allowCache());
+
+		$headers = $object->getHeaders();
+
+		$this->assertSame(
+			array(
+				'name'  => 'Content-Type',
+				'value' => 'text/html; charset=utf-8'
+			),
+			$headers[0]
+		);
+
+		$this->assertEmpty($object->getBody());
+	}
+
+	/**
 	 * @testdox  Tests that the application with compression enabled is executed successfully.
 	 *
 	 * @covers  Joomla\Application\AbstractWebApplication::execute

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
     "license": "GPL-2.0+",
     "require": {
         "php": "~7.0",
+        "joomla/event": "~2.0",
         "joomla/input": "~1.2|~2.0",
         "joomla/registry": "^1.4.5|~2.0",
         "psr/log": "~1.0",

--- a/src/AbstractWebApplication.php
+++ b/src/AbstractWebApplication.php
@@ -201,12 +201,12 @@ abstract class AbstractWebApplication extends AbstractApplication
 	 */
 	public function execute()
 	{
-		// @event onBeforeExecute
+		$this->dispatchEvent(ApplicationEvents::BEFORE_EXECUTE);
 
 		// Perform application routines.
 		$this->doExecute();
 
-		// @event onAfterExecute
+		$this->dispatchEvent(ApplicationEvents::AFTER_EXECUTE);
 
 		// If gzip compression is enabled in configuration and the server is compliant, compress the output.
 		if ($this->get('gzip') && !ini_get('zlib.output_compression') && (ini_get('output_handler') != 'ob_gzhandler'))
@@ -214,12 +214,12 @@ abstract class AbstractWebApplication extends AbstractApplication
 			$this->compress();
 		}
 
-		// @event onBeforeRespond
+		$this->dispatchEvent(ApplicationEvents::BEFORE_RESPOND);
 
 		// Send the application response.
 		$this->respond();
 
-		// @event onAfterRespond
+		$this->dispatchEvent(ApplicationEvents::AFTER_RESPOND);
 	}
 
 	/**

--- a/src/ApplicationEvents.php
+++ b/src/ApplicationEvents.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Part of the Joomla Framework Application Package
+ *
+ * @copyright  Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Application;
+
+/**
+ * Class defining the events available in the application.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+final class ApplicationEvents
+{
+	/**
+	 * The BEFORE_EXECUTE event is an event triggered before the application is executed.
+	 *
+	 * @var    string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	const BEFORE_EXECUTE = 'application.before_execute';
+
+	/**
+	 * The AFTER_EXECUTE event is an event triggered after the application is executed.
+	 *
+	 * @var    string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	const AFTER_EXECUTE = 'application.after_execute';
+
+	/**
+	 * The BEFORE_RESPOND event is an event triggered before the application response is sent.
+	 *
+	 * @var    string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	const BEFORE_RESPOND = 'application.before_respond';
+
+	/**
+	 * The AFTER_RESPOND event is an event triggered after the application response is sent.
+	 *
+	 * @var    string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	const AFTER_RESPOND = 'application.after_respond';
+}

--- a/src/Event/ApplicationEvent.php
+++ b/src/Event/ApplicationEvent.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Part of the Joomla Framework Application Package
+ *
+ * @copyright  Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Application\Event;
+
+use Joomla\Application\AbstractApplication;
+use Joomla\Event\Event;
+
+/**
+ * Base event class for application events.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class ApplicationEvent extends Event
+{
+	/**
+	 * The active application.
+	 *
+	 * @var    AbstractApplication
+	 * @since  __DEPLOY_VERSION__
+	 */
+	private $application;
+
+	/**
+	 * Event constructor.
+	 *
+	 * @param   string               $name         The event name.
+	 * @param   AbstractApplication  $application  The active application.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function __construct(string $name, AbstractApplication $application)
+	{
+		parent::__construct($name);
+
+		$this->application = $application;
+	}
+
+	/**
+	 * Get the active application.
+	 *
+	 * @return  AbstractApplication
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getApplication(): AbstractApplication
+	{
+		return $this->application;
+	}
+}


### PR DESCRIPTION
### Summary of Changes

The Framework was largely decoupled, unopinionated, and a lot of effort went into making packages independent which resulted in some basic functionality as compared to the Platform and CMS not being available.  Let's try to reverse course on this a little bit.

Basic event support is now restored to the base abstract application and the web application (as they're the only two with `execute()` methods).  Events will be triggered at four integration points:

- Before/After the `doExecute()` call
- For web applications, before/after the `render()` call

### Documentation Changes Required

Note support for events and what the event objects are

### Future Considerations

Should events on the web application be able to possibly interrupt the workflow, somewhat similar to Symfony's Kernel events (i.e. if the before execute event sets a response, don't trigger the `doExecute` call).