### PR TITLE
Deprecate the CLI classes in favor of the Console package

### DIFF
--- a/src/AbstractCliApplication.php
+++ b/src/AbstractCliApplication.php
@@ -14,7 +14,8 @@ use Joomla\Registry\Registry;
 /**
  * Base class for a Joomla! command line application.
  *
- * @since  1.0
+ * @since       1.0
+ * @deprecated  2.0  Use the `joomla/console` package instead
  */
 abstract class AbstractCliApplication extends AbstractApplication
 {

--- a/src/Cli/CliInput.php
+++ b/src/Cli/CliInput.php
@@ -11,7 +11,8 @@ namespace Joomla\Application\Cli;
 /**
  * Class CliInput
  *
- * @since  1.6.0
+ * @since       1.6.0
+ * @deprecated  2.0  Use the `joomla/console` package instead
  */
 class CliInput
 {

--- a/src/Cli/CliOutput.php
+++ b/src/Cli/CliOutput.php
@@ -13,7 +13,8 @@ use Joomla\Application\Cli\Output\Processor\ProcessorInterface;
 /**
  * Class CliOutput
  *
- * @since  1.0
+ * @since       1.0
+ * @deprecated  2.0  Use the `joomla/console` package instead
  */
 abstract class CliOutput
 {

--- a/src/Cli/ColorProcessor.php
+++ b/src/Cli/ColorProcessor.php
@@ -14,7 +14,7 @@ use \Joomla\Application\Cli\Output\Processor\ColorProcessor as RealColorProcesso
  * Class ColorProcessor.
  *
  * @since       1.0
- * @deprecated  2.0 Use \Joomla\Application\Cli\Output\Processor\ColorProcessor
+ * @deprecated  2.0  Use the `joomla/console` package instead
  */
 class ColorProcessor extends RealColorProcessor
 {

--- a/src/Cli/ColorStyle.php
+++ b/src/Cli/ColorStyle.php
@@ -11,7 +11,8 @@ namespace Joomla\Application\Cli;
 /**
  * Class ColorStyle
  *
- * @since  1.0
+ * @since       1.0
+ * @deprecated  2.0  Use the `joomla/console` package instead
  */
 final class ColorStyle
 {

--- a/src/Cli/Output/Processor/ColorProcessor.php
+++ b/src/Cli/Output/Processor/ColorProcessor.php
@@ -14,7 +14,8 @@ use Joomla\Application\Cli\Output\Stdout;
 /**
  * Class ColorProcessor.
  *
- * @since  1.0
+ * @since       1.0
+ * @deprecated  2.0  Use the `joomla/console` package instead
  */
 class ColorProcessor implements ProcessorInterface
 {

--- a/src/Cli/Output/Processor/ProcessorInterface.php
+++ b/src/Cli/Output/Processor/ProcessorInterface.php
@@ -11,7 +11,8 @@ namespace Joomla\Application\Cli\Output\Processor;
 /**
  * Class ProcessorInterface.
  *
- * @since  1.1.0
+ * @since       1.1.0
+ * @deprecated  2.0  Use the `joomla/console` package instead
  */
 interface ProcessorInterface
 {

--- a/src/Cli/Output/Stdout.php
+++ b/src/Cli/Output/Stdout.php
@@ -13,7 +13,8 @@ use Joomla\Application\Cli\CliOutput;
 /**
  * Class Stdout.
  *
- * @since  1.0
+ * @since       1.0
+ * @deprecated  2.0  Use the `joomla/console` package instead
  */
 class Stdout extends CliOutput
 {

--- a/src/Cli/Output/Xml.php
+++ b/src/Cli/Output/Xml.php
@@ -13,7 +13,8 @@ use Joomla\Application\Cli\CliOutput;
 /**
  * Class Xml.
  *
- * @since  1.0
+ * @since       1.0
+ * @deprecated  2.0  Use the `joomla/console` package instead
  */
 class Xml extends CliOutput
 {


### PR DESCRIPTION
Pull Request for Issue #75

### Summary of Changes

Deprecates the CLI application and its supporting classes in favor of the new Console package.
