### PR TITLE
Occasional problem of corrupted html

### DIFF
--- a/Tests/AbstractWebApplicationTest.php
+++ b/Tests/AbstractWebApplicationTest.php
@@ -327,7 +327,8 @@ class AbstractWebApplicationTest extends \PHPUnit_Framework_TestCase
 		$this->assertSame(
 			array(
 				0 => array('name' => 'Content-Encoding', 'value' => 'deflate'),
-				1 => array('name' => 'X-Content-Encoded-By', 'value' => 'Joomla')
+				1 => array('name' => 'Vary', 'value' => 'Accept-Encoding'),
+				2 => array('name' => 'X-Content-Encoded-By', 'value' => 'Joomla')
 			),
 			$object->getHeaders()
 		);

--- a/Tests/AbstractWebApplicationTest.php
+++ b/Tests/AbstractWebApplicationTest.php
@@ -263,7 +263,8 @@ class AbstractWebApplicationTest extends \PHPUnit_Framework_TestCase
 		$this->assertSame(
 			array(
 				0 => array('name' => 'Content-Encoding', 'value' => 'gzip'),
-				1 => array('name' => 'X-Content-Encoded-By', 'value' => 'Joomla')
+				1 => array('name' => 'Vary', 'value' => 'Accept-Encoding'),
+				2 => array('name' => 'X-Content-Encoded-By', 'value' => 'Joomla')
 			),
 			$object->getHeaders()
 		);

--- a/src/AbstractWebApplication.php
+++ b/src/AbstractWebApplication.php
@@ -270,6 +270,7 @@ abstract class AbstractWebApplication extends AbstractApplication
 
 				// Set the encoding headers.
 				$this->setHeader('Content-Encoding', $encoding);
+				$this->setHeader('Vary', 'Accept-Encoding');
 				$this->setHeader('X-Content-Encoded-By', 'Joomla');
 
 				// Replace the output with the encoded data.


### PR DESCRIPTION
When the compression of the response is delegated to Apache with mod_deflate, two headers are set during the compression:
```
Content-Encoding: gzip
Vary: Accept-Encoding
```

Vary: Accept-Encoding is important to prevent proxies, intermediate caches, or CDNs from serving compressed resource to clients that does not support compression and vice versa.
"Vary: Accept-Encoding" header specifies that caches should only be used if the incoming request matches the "Accept-Encoding" information in the cache.

When the mod_deflate is disabled in the web server, and the compression is delegated to Joomla through Global Configuration → Server → Gzip Page Compression, in this case the header "Content-Encoding: gzip" is set, but "Vary: Accept-Encoding" no, which causes the problem mentioned above on modern networks.

### Testing Instructions
Disable mod_deflate in your web server and enable Joomla compression Global Configuration → Server → Gzip Page Compression.
Browse any page.
Check that the response headers include Vary: Accept-Encoding in addition to Content-Encoding: gzip

### Note
See https://github.com/joomla/joomla-cms/pull/19525