### PR TITLE
CSRF DX improvements

### DIFF
--- a/docs/v1-to-v2-update.md
+++ b/docs/v1-to-v2-update.md
@@ -11,11 +11,6 @@ In order to support PSR-7 responses there is a single break in backwards incompa
 
 The package internals use the Zend Framework [Diactoros package](https://github.com/zendframework/zend-diactoros) for building the Response object. If you wish to use another PSR-7 compatible library you will need to extend the `setHeader`, `getHeaders`, `clearHeaders`, `setBody`, `prependBody`, and `appendBody` methods.
 
-### AbstractWebApplication::getFormToken is now an abstract method
-The method `\Joomla\Application\AbstractWebApplication::getFormToken` has been made an
-abstract method. Application's should specify their own logic here to generate a form
-token.
-
 ### CLI Classes Removed
 
 The `\Joomla\Application\AbstractCliApplication` and all `Joomla\Application\Cli` namespace classes have been removed. The new `joomla/console` package should be used going forward.

--- a/docs/v1-to-v2-update.md
+++ b/docs/v1-to-v2-update.md
@@ -11,6 +11,9 @@ In order to support PSR-7 responses there is a single break in backwards incompa
 
 The package internals use the Zend Framework [Diactoros package](https://github.com/zendframework/zend-diactoros) for building the Response object. If you wish to use another PSR-7 compatible library you will need to extend the `setHeader`, `getHeaders`, `clearHeaders`, `setBody`, `prependBody`, and `appendBody` methods.
 
+### AbstractWebApplication::checkToken now validates a token
+The method `\Joomla\Application\AbstractWebApplication::checkToken` has been changed to validate a token in addition to checking if it is present in the request. Additionally, the homepage redirect on an invalid token has been removed.
+
 ### CLI Classes Removed
 
 The `\Joomla\Application\AbstractCliApplication` and all `Joomla\Application\Cli` namespace classes have been removed. The new `joomla/console` package should be used going forward.

--- a/src/AbstractWebApplication.php
+++ b/src/AbstractWebApplication.php
@@ -1032,7 +1032,10 @@ abstract class AbstractWebApplication extends AbstractApplication
 	 *
 	 * @since   1.0
 	 */
-	abstract public function getFormToken($forceNew = false);
+	public function getFormToken($forceNew = false)
+	{
+		return $this->getSession()->getToken($forceNew);
+	}
 
 	/**
 	 * Tests whether a string contains only 7bit ASCII bytes.

--- a/src/AbstractWebApplication.php
+++ b/src/AbstractWebApplication.php
@@ -997,11 +997,9 @@ abstract class AbstractWebApplication extends AbstractApplication
 	/**
 	 * Checks for a form token in the request.
 	 *
-	 * Use in conjunction with getFormToken.
-	 *
 	 * @param   string  $method  The request method in which to look for the token key.
 	 *
-	 * @return  boolean  True if found and valid, false otherwise.
+	 * @return  boolean
 	 *
 	 * @since   1.0
 	 */
@@ -1011,16 +1009,10 @@ abstract class AbstractWebApplication extends AbstractApplication
 
 		if (!$this->input->$method->get($token, '', 'alnum'))
 		{
-			if ($this->getSession()->isNew())
-			{
-				// Redirect to login screen.
-				$this->redirect('index.php');
-			}
-
 			return false;
 		}
 
-		return true;
+		return $this->getSession()->hasToken($token);
 	}
 
 	/**


### PR DESCRIPTION
### Summary of Changes

- Makes the `getFormToken` a concrete method again, by default calling `$this->getSession()->getToken();`
- Changes `checkToken` so that
    - It also validates the token against the session
    - Does not arbitrarily redirect to an `index.php` file if the session is new

Given the inherent coupling to a session for most use cases with CSRF, having these two methods internally dependent on a session being registered to the application seems perfectly fine