### PR TITLE
[2.0] Add a controller resolver and a concrete web application

### DIFF
--- a/Tests/Controller/ContainerControllerResolverTest.php
+++ b/Tests/Controller/ContainerControllerResolverTest.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * @copyright  Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Application\Tests\Controller;
+
+use Joomla\Application\Controller\ContainerControllerResolver;
+use Joomla\Application\Controller\ControllerResolver;
+use Joomla\Application\Event\ApplicationEvent;
+use Joomla\Application\Tests\Stubs\Controller;
+use Joomla\Application\Tests\Stubs\HasArgumentsController;
+use Joomla\DI\Container;
+use Joomla\Registry\Registry;
+use Joomla\Router\ResolvedRoute;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test class for Joomla\Application\Controller\ContainerControllerResolver.
+ */
+class ContainerControllerResolverTest extends TestCase
+{
+	/**
+	 * Resolver under test
+	 *
+	 * @var  ContainerControllerResolver
+	 */
+	private $resolver;
+
+	/**
+	 * Sets up the fixture, for example, open a network connection.
+	 * This method is called before a test is executed.
+	 */
+	protected function setUp()
+	{
+		$container = new Container;
+		$container->set(
+			Controller::class,
+			function ()
+			{
+				return new Controller;
+			}
+		);
+
+		$this->resolver = new ContainerControllerResolver($container);
+	}
+
+	/**
+	 * @testdox  Tests the resolver resolves a ControllerInterface
+	 *
+	 * @covers  Joomla\Application\Controller\ControllerResolver::resolve
+	 */
+	public function testResolvingAControllerInterface()
+	{
+		$callable = $this->resolver->resolve(new ResolvedRoute(Controller::class, [], '/'));
+
+		$this->assertTrue(is_callable($callable));
+		$this->assertInstanceOf(Controller::class, $callable[0]);
+	}
+
+	/**
+	 * @testdox  Tests the resolver resolves a ControllerInterface but fails instantiating a class with required arguments
+	 *
+	 * @covers   Joomla\Application\Controller\ControllerResolver::resolve
+	 * @requires  PHP 7.1
+	 *
+	 * @expectedException  \InvalidArgumentException
+	 * @expectedExceptionMessage  Controller `Joomla\Application\Tests\Stubs\HasArgumentsController` has required constructor arguments, cannot instantiate the class
+	 */
+	public function testResolvingControllerInterfaceFailsOnAClassWithRequiredArguments()
+	{
+		$this->resolver->resolve(new ResolvedRoute(HasArgumentsController::class, [], '/'));
+	}
+}

--- a/Tests/Controller/ControllerResolverTest.php
+++ b/Tests/Controller/ControllerResolverTest.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * @copyright  Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Application\Tests\Controller;
+
+use Joomla\Application\Controller\ControllerResolver;
+use Joomla\Application\Event\ApplicationEvent;
+use Joomla\Application\Tests\Stubs\Controller;
+use Joomla\Application\Tests\Stubs\HasArgumentsController;
+use Joomla\Registry\Registry;
+use Joomla\Router\ResolvedRoute;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test class for Joomla\Application\Controller\ControllerResolver.
+ */
+class ControllerResolverTest extends TestCase
+{
+	/**
+	 * @testdox  Tests the resolver resolves a callable array
+	 *
+	 * @covers  Joomla\Application\Controller\ControllerResolver::resolve
+	 */
+	public function testResolvingACallableArray()
+	{
+		$callable = (new ControllerResolver)->resolve(new ResolvedRoute([Registry::class, 'get'], [], '/'));
+
+		$this->assertTrue(is_callable($callable));
+		$this->assertInstanceOf(Registry::class, $callable[0]);
+	}
+
+	/**
+	 * @testdox  Tests the resolver fails to resolve an array that is not callable
+	 *
+	 * @covers   Joomla\Application\Controller\ControllerResolver::resolve
+	 *
+	 * @expectedException  \InvalidArgumentException
+	 * @expectedExceptionMessage  Cannot resolve controller for URI `/`
+	 */
+	public function testResolvingAnArrayFailsWhenNonCollable()
+	{
+		(new ControllerResolver)->resolve(new ResolvedRoute([Registry::class, 'noWayThisWillEverExist'], [], '/'));
+	}
+
+	/**
+	 * @testdox  Tests the resolver resolves a callable array but fails instantiating a class with required arguments
+	 *
+	 * @covers   Joomla\Application\Controller\ControllerResolver::resolve
+	 * @requires  PHP 7.1
+	 *
+	 * @expectedException  \InvalidArgumentException
+	 * @expectedExceptionMessage  Controller `Joomla\Application\Event\ApplicationEvent` has required constructor arguments, cannot instantiate the class
+	 */
+	public function testResolvingACallableArrayFailsOnAClassWithRequiredArguments()
+	{
+		(new ControllerResolver)->resolve(new ResolvedRoute([ApplicationEvent::class, 'getApplication'], [], '/'));
+	}
+
+	/**
+	 * @testdox  Tests the resolver resolves a callable object
+	 *
+	 * @covers  Joomla\Application\Controller\ControllerResolver::resolve
+	 */
+	public function testResolvingACallableObject()
+	{
+		$controller = function ()
+		{
+			return 'Hello world!';
+		};
+
+		$this->assertSame($controller, (new ControllerResolver)->resolve(new ResolvedRoute($controller, [], '/')));
+	}
+
+	/**
+	 * @testdox  Tests the resolver resolves a callable function
+	 *
+	 * @covers  Joomla\Application\Controller\ControllerResolver::resolve
+	 */
+	public function testResolvingACallableFunction()
+	{
+		$this->assertSame('str_replace', (new ControllerResolver)->resolve(new ResolvedRoute('str_replace', [], '/')));
+	}
+
+	/**
+	 * @testdox  Tests the resolver resolves a ControllerInterface
+	 *
+	 * @covers  Joomla\Application\Controller\ControllerResolver::resolve
+	 */
+	public function testResolvingAControllerInterface()
+	{
+		$callable = (new ControllerResolver)->resolve(new ResolvedRoute(Controller::class, [], '/'));
+
+		$this->assertTrue(is_callable($callable));
+		$this->assertInstanceOf(Controller::class, $callable[0]);
+	}
+
+	/**
+	 * @testdox  Tests the resolver resolves a ControllerInterface but fails instantiating a class with required arguments
+	 *
+	 * @covers   Joomla\Application\Controller\ControllerResolver::resolve
+	 * @requires  PHP 7.1
+	 *
+	 * @expectedException  \InvalidArgumentException
+	 * @expectedExceptionMessage  Controller `Joomla\Application\Tests\Stubs\HasArgumentsController` has required constructor arguments, cannot instantiate the class
+	 */
+	public function testResolvingControllerInterfaceFailsOnAClassWithRequiredArguments()
+	{
+		(new ControllerResolver)->resolve(new ResolvedRoute(HasArgumentsController::class, [], '/'));
+	}
+}

--- a/Tests/Stubs/Controller.php
+++ b/Tests/Stubs/Controller.php
@@ -6,9 +6,9 @@
 
 namespace Joomla\Application\Tests\Stubs;
 
-use Joomla\Controller\ControllerInterface;
+use Joomla\Controller\AbstractController;
 
-class Controller implements ControllerInterface
+class Controller extends AbstractController
 {
 	public function execute()
 	{

--- a/Tests/Stubs/Controller.php
+++ b/Tests/Stubs/Controller.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * @copyright  Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Application\Tests\Stubs;
+
+use Joomla\Controller\ControllerInterface;
+
+class Controller implements ControllerInterface
+{
+	public function execute()
+	{
+		return 'Hello world!';
+	}
+
+	public function serialize()
+	{
+		return serialize('');
+	}
+
+	public function unserialize($serialized)
+	{
+		// Nothing to unserialize
+	}
+}

--- a/Tests/Stubs/HasArgumentsController.php
+++ b/Tests/Stubs/HasArgumentsController.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * @copyright  Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Application\Tests\Stubs;
+
+use Joomla\Controller\ControllerInterface;
+
+class HasArgumentsController implements ControllerInterface
+{
+	private $name;
+
+	public function __construct(string $name)
+	{
+		$this->name = $name;
+	}
+
+	public function execute()
+	{
+		return 'Hello ' . $this->name . '!';
+	}
+
+	public function serialize()
+	{
+		return serialize(
+			[
+				'name' => $this->name,
+			]
+		);
+	}
+
+	public function unserialize($serialized)
+	{
+		list($this->name) = unserialize($serialized);
+	}
+}

--- a/Tests/Stubs/HasArgumentsController.php
+++ b/Tests/Stubs/HasArgumentsController.php
@@ -6,9 +6,9 @@
 
 namespace Joomla\Application\Tests\Stubs;
 
-use Joomla\Controller\ControllerInterface;
+use Joomla\Controller\AbstractController;
 
-class HasArgumentsController implements ControllerInterface
+class HasArgumentsController extends AbstractController
 {
 	private $name;
 

--- a/Tests/WebApplicationTest.php
+++ b/Tests/WebApplicationTest.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * @copyright  Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Application\Tests;
+
+use Joomla\Application\Controller\ControllerResolverInterface;
+use Joomla\Application\WebApplication;
+use Joomla\Router\ResolvedRoute;
+use Joomla\Router\Router;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test class for Joomla\Application\WebApplication.
+ */
+class WebApplicationTest extends TestCase
+{
+	/**
+	 * @testdox  Tests that the application is executed successfully.
+	 *
+	 * @covers  Joomla\Application\WebApplication::doExecute
+	 */
+	public function testExecute()
+	{
+		$controller = new class
+		{
+			private $executed = false;
+
+			public function __invoke()
+			{
+				$this->executed = true;
+			}
+
+			public function isExecuted(): bool
+			{
+				return $this->executed === true;
+			}
+		};
+
+		$route = new ResolvedRoute($controller, [], '/');
+
+		$router = $this->getMockBuilder(Router::class)
+			->getMock();
+
+		$router->expects($this->once())
+			->method('parseRoute')
+			->willReturn($route);
+
+		$resolver = $this->getMockBuilder(ControllerResolverInterface::class)
+			->getMock();
+
+		$resolver->expects($this->once())
+			->method('resolve')
+			->with($route)
+			->willReturn($controller);
+
+		(new WebApplication($resolver, $router))->execute();
+
+		$this->assertTrue($controller->isExecuted());
+	}
+}

--- a/Tests/WebApplicationTest.php
+++ b/Tests/WebApplicationTest.php
@@ -8,8 +8,10 @@ namespace Joomla\Application\Tests;
 
 use Joomla\Application\Controller\ControllerResolverInterface;
 use Joomla\Application\WebApplication;
+use Joomla\Input\Input;
 use Joomla\Router\ResolvedRoute;
 use Joomla\Router\Router;
+use Joomla\Test\TestHelper;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -17,6 +19,22 @@ use PHPUnit\Framework\TestCase;
  */
 class WebApplicationTest extends TestCase
 {
+	/**
+	 * Enable or disable the backup and restoration of the $GLOBALS array.
+	 * Overwrite this attribute in a child class of TestCase.
+	 * Setting this attribute in setUp() has no effect!
+	 *
+	 * @var bool
+	 */
+	protected $backupGlobals = true;
+
+	/**
+	 * This method is called before the first test of this test class is run.
+	 */
+	public static function setUpBeforeClass()
+	{
+	}
+
 	/**
 	 * @testdox  Tests that the application is executed successfully.
 	 *
@@ -56,7 +74,26 @@ class WebApplicationTest extends TestCase
 			->with($route)
 			->willReturn($controller);
 
-		(new WebApplication($resolver, $router))->execute();
+		// For joomla/input 2.0
+		$mockInput = new Input([]);
+
+		// Mock the Input object internals
+		$mockServerInput = new Input(
+			[
+				'REQUEST_METHOD' => 'GET',
+			]
+		);
+
+		$inputInternals = [
+			'server' => $mockServerInput,
+		];
+
+		TestHelper::setValue($mockInput, 'inputs', $inputInternals);
+
+		// For joomla/input 1.0
+		$_SERVER['REQUEST_METHOD'] = 'GET';
+
+		(new WebApplication($resolver, $router, $mockInput))->execute();
 
 		$this->assertTrue($controller->isExecuted());
 	}

--- a/composer.json
+++ b/composer.json
@@ -26,9 +26,10 @@
     },
     "suggest": {
         "joomla/controller": "To support resolving ControllerInterface objects in ControllerResolverInterface, install joomla/controller",
-        "joomla/router": "To use ControllerResolverInterface implementations, install joomla/router",
+        "joomla/router": "To use WebApplication or ControllerResolverInterface implementations, install joomla/router",
         "joomla/session": "To use AbstractWebApplication with session support, install joomla/session",
-        "joomla/uri": "To use AbstractWebApplication, install joomla/uri"
+        "joomla/uri": "To use AbstractWebApplication, install joomla/uri",
+        "psr/container": "To use the ContainerControllerResolver, install any PSR-11 compatible container"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -16,13 +16,17 @@
     },
     "require-dev": {
         "joomla/coding-standards": "~2.0@alpha",
-        "joomla/event": "~2.0",
+        "joomla/controller": "~1.0|~2.0",
+        "joomla/di": "~1.5|~2.0",
+        "joomla/router": "~2.0",
         "joomla/session": "~2.0",
         "joomla/test": "~1.1",
         "joomla/uri": "~1.1",
         "phpunit/phpunit": "~6.3"
     },
     "suggest": {
+        "joomla/controller": "To support resolving ControllerInterface objects in ControllerResolverInterface, install joomla/controller",
+        "joomla/router": "To use ControllerResolverInterface implementations, install joomla/router",
         "joomla/session": "To use AbstractWebApplication with session support, install joomla/session",
         "joomla/uri": "To use AbstractWebApplication, install joomla/uri"
     },

--- a/src/Controller/ContainerControllerResolver.php
+++ b/src/Controller/ContainerControllerResolver.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Part of the Joomla Framework Application Package
+ *
+ * @copyright  Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Application\Controller;
+
+use Psr\Container\ContainerInterface;
+
+/**
+ * Controller resolver which supports creating controllers from a PSR-11 compatible container
+ *
+ * Controllers must be registered in the container using their FQCN as a service key
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class ContainerControllerResolver extends ControllerResolver
+{
+	/**
+	 * The container to search for controllers in
+	 *
+	 * @var    ContainerInterface
+	 * @since  __DEPLOY_VERSION__
+	 */
+	private $container;
+
+	/**
+	 * Constructor
+	 *
+	 * @param   ContainerInterface  $container  The container to search for controllers in
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function __construct(ContainerInterface $container)
+	{
+		$this->container = $container;
+	}
+
+	/**
+	 * Instantiate a controller class
+	 *
+	 * @param   string  $class  The class to instantiate
+	 *
+	 * @return  object  Controller class instance
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected function instantiateController(string $class)
+	{
+		if ($this->container->has($class))
+		{
+			return $this->container->get($class);
+		}
+
+		return parent::instantiateController($class);
+	}
+}

--- a/src/Controller/ControllerResolver.php
+++ b/src/Controller/ControllerResolver.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * Part of the Joomla Framework Application Package
+ *
+ * @copyright  Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Application\Controller;
+
+use Joomla\Controller\ControllerInterface;
+use Joomla\Router\ResolvedRoute;
+
+/**
+ * Resolves a controller for the given route.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class ControllerResolver implements ControllerResolverInterface
+{
+	/**
+	 * Resolve the controller for a route
+	 *
+	 * @param   ResolvedRoute  $route  The route to resolve the controller for
+	 *
+	 * @return  callable
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  \InvalidArgumentException
+	 */
+	public function resolve(ResolvedRoute $route): callable
+	{
+		$controller = $route->getController();
+
+		// Try to resolve a callable defined as an array
+		if (is_array($controller))
+		{
+			if (isset($controller[0]) && is_string($controller[0]) && isset($controller[1]))
+			{
+				if (!class_exists($controller[0]))
+				{
+					throw new \InvalidArgumentException(sprintf('Cannot resolve controller for URI `%s`', $route->getUri()));
+				}
+
+				try
+				{
+					$controller[0] = $this->instantiateController($controller[0]);
+				}
+				catch (\ArgumentCountError $error)
+				{
+					// On PHP 7.1, we can catch missing argument errors to provide a more useful error message
+					throw new \InvalidArgumentException(
+						sprintf(
+							'Controller `%s` has required constructor arguments, cannot instantiate the class', $controller[0]
+						),
+						0,
+						$error
+					);
+				}
+			}
+
+			if (!is_callable($controller))
+			{
+				throw new \InvalidArgumentException(sprintf('Cannot resolve controller for URI `%s`', $route->getUri()));
+			}
+
+			return $controller;
+		}
+
+		// Try to resolve an invokable object
+		if (is_object($controller))
+		{
+			if (!is_callable($controller))
+			{
+				throw new \InvalidArgumentException(sprintf('Cannot resolve controller for URI `%s`', $route->getUri()));
+			}
+
+			return $controller;
+		}
+
+		// Try to resolve a known function
+		if (function_exists($controller))
+		{
+			return $controller;
+		}
+
+		// Try to resolve a class name if it implements our ControllerInterface
+		if (is_string($controller) && interface_exists(ControllerInterface::class))
+		{
+			if (!class_exists($controller))
+			{
+				throw new \InvalidArgumentException(sprintf('Cannot resolve controller for URI `%s`', $route->getUri()));
+			}
+
+			try
+			{
+				return [$this->instantiateController($controller), 'execute'];
+			}
+			catch (\ArgumentCountError $error)
+			{
+				// On PHP 7.1, we can catch missing argument errors to provide a more useful error message
+				throw new \InvalidArgumentException(
+					sprintf(
+						'Controller `%s` has required constructor arguments, cannot instantiate the class', $controller
+					),
+					0,
+					$error
+				);
+			}
+		}
+
+		// Unsupported resolution
+		throw new \InvalidArgumentException(sprintf('Cannot resolve controller for URI `%s`', $route->getUri()));
+	}
+
+	/**
+	 * Instantiate a controller class
+	 *
+	 * @param   string  $class  The class to instantiate
+	 *
+	 * @return  object  Controller class instance
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected function instantiateController(string $class)
+	{
+		return new $class;
+	}
+}

--- a/src/Controller/ControllerResolverInterface.php
+++ b/src/Controller/ControllerResolverInterface.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Part of the Joomla Framework Application Package
+ *
+ * @copyright  Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Application\Controller;
+
+use Joomla\Router\ResolvedRoute;
+
+/**
+ * Interface defining a controller resolver.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+interface ControllerResolverInterface
+{
+	/**
+	 * Resolve the controller for a route
+	 *
+	 * @param   ResolvedRoute  $route  The route to resolve the controller for
+	 *
+	 * @return  callable
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  \InvalidArgumentException
+	 */
+	public function resolve(ResolvedRoute $route): callable;
+}

--- a/src/WebApplication.php
+++ b/src/WebApplication.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Part of the Joomla Framework Application Package
+ *
+ * @copyright  Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Application;
+
+use Joomla\Application\Controller\ControllerResolverInterface;
+use Joomla\Input\Input;
+use Joomla\Registry\Registry;
+use Joomla\Router\Router;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * A basic web application class for handing HTTP requests.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class WebApplication extends AbstractWebApplication
+{
+	/**
+	 * The application's controller resolver.
+	 *
+	 * @var    ControllerResolverInterface
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $controllerResolver;
+
+	/**
+	 * The application's router.
+	 *
+	 * @var    Router
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $router;
+
+	/**
+	 * Class constructor.
+	 *
+	 * @param   ControllerResolverInterface  $controllerResolver  The application's controller resolver
+	 * @param   Router                       $router              The application's router
+	 * @param   Input                        $input               An optional argument to provide dependency injection for the application's
+	 *                                                            input object.  If the argument is an Input object that object will become
+	 *                                                            the application's input object, otherwise a default input object is
+	 *                                                            created.
+	 * @param   Registry                     $config              An optional argument to provide dependency injection for the application's
+	 *                                                            config object.  If the argument is a Registry object that object will
+	 *                                                            become the application's config object, otherwise a default config object
+	 *                                                            is created.
+	 * @param   Web\WebClient                $client              An optional argument to provide dependency injection for the application's
+	 *                                                            client object.  If the argument is a Web\WebClient object that object will
+	 *                                                            become the application's client object, otherwise a default client object
+	 *                                                            is created.
+	 * @param   ResponseInterface            $response            An optional argument to provide dependency injection for the application's
+	 *                                                            response object.  If the argument is a ResponseInterface object that object
+	 *                                                            will become the application's response object, otherwise a default response
+	 *                                                            object is created.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function __construct(
+		ControllerResolverInterface $controllerResolver,
+		Router $router,
+		Input $input = null,
+		Registry $config = null,
+		Web\WebClient $client = null,
+		ResponseInterface $response = null
+	)
+	{
+		$this->controllerResolver = $controllerResolver;
+		$this->router             = $router;
+
+		// Call the constructor as late as possible (it runs `initialise`).
+		parent::__construct($input, $config, $client, $response);
+	}
+
+	/**
+	 * Method to run the application routines.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected function doExecute()
+	{
+		$route = $this->router->parseRoute($this->get('uri.route'), $this->input->getMethod());
+
+		// Add variables to the input if not already set
+		foreach ($route->getRouteVariables() as $key => $value)
+		{
+			$this->input->def($key, $value);
+		}
+
+		call_user_func($this->controllerResolver->resolve($route));
+	}
+}


### PR DESCRIPTION
### Summary of Changes

Note: Requires https://github.com/joomla-framework/router/pull/12 and CI will fail without it

There are some tools we can provide to help getting web applications deployed a little quicker, and that's what this PR provides.

Item 1 - A controller resolver.  In 1.x this really didn't make sense to need because the router was coded in a way where a controller had to map to a `Joomla\Controller\ControllerInterface` implementation, that requirement is removed in the 2.0 code and controllers can now be any kind of callable.  Based loosely on the resolver in Symfony's HttpKernel component, our implementation can support:

- Any invokable object (i.e. a Closure or a class with `__invoke`
- A standard callback array (i.e. `[ControllerInterface::class, 'execute']`
- Any declared PHP function
- A class name if the class implements `Joomla\Controller\ControllerInterface`
- Via an optional subclass, a controller defined as a service in any PSR-11 compatible container

Item 2 - A concrete web application.  The basics of our web application are to route the request and execute a controller.  Without a controller resolver, it has never made sense to have a concrete application because downstream implementations were left to handle controller resolution and execution on their own.  With the resolver, we can now ship this concrete implementation fulfilling these basic functions.

### Testing Instructions

Review unit tests for basic use of these two features

### Documentation Changes Required

A "getting started" guide can be much more simple now 😄