### PR TITLE
Allow SSL offloading at loadbalancer

### DIFF
--- a/src/AbstractWebApplication.php
+++ b/src/AbstractWebApplication.php
@@ -788,10 +788,15 @@ abstract class AbstractWebApplication extends AbstractApplication
 	public function isSslConnection()
 	{
 		$serverSSLVar = $this->input->server->getString('HTTPS', '');
+
+		if (!empty($serverSSLVar) && strtolower($serverSSLVar) !== 'off')
+		{
+			return true;
+		}
+
 		$serverForwarderProtoVar = $this->input->server->getString('HTTP_X_FORWARDED_PROTO', '');
 
-		return (!empty($serverSSLVar) && strtolower($serverSSLVar) != 'off') ||
-		(!empty($serverForwarderProtoVar) && strtolower($serverForwarderProtoVar) == 'https');;
+		return !empty($serverForwarderProtoVar) && strtolower($serverForwarderProtoVar) === 'https';
 	}
 
 	/**

--- a/src/AbstractWebApplication.php
+++ b/src/AbstractWebApplication.php
@@ -788,8 +788,10 @@ abstract class AbstractWebApplication extends AbstractApplication
 	public function isSslConnection()
 	{
 		$serverSSLVar = $this->input->server->getString('HTTPS', '');
+		$serverForwarderProtoVar = $this->input->server->getString('HTTP_X_FORWARDED_PROTO', '');
 
-		return (!empty($serverSSLVar) && strtolower($serverSSLVar) != 'off');
+		return (!empty($serverSSLVar) && strtolower($serverSSLVar) != 'off') ||
+		(!empty($serverForwarderProtoVar) && strtolower($serverForwarderProtoVar) == 'https');;
 	}
 
 	/**


### PR DESCRIPTION
Allow for SSL offloading at loadbalancer level while still letting Joomla know it is working in HTTPS mode

Pull Request for Issue https://github.com/joomla/joomla-cms/issues/9756

### Summary of Changes
This changes the way that Joomla checks if HTTPS is enabled when SSL offloading is taking place at a proxy or a loadbalancer for example.

### Testing Instructions
Configure your server to add a header HTTP_X_FORWARDED_PROTO "https"
With nginx:
proxy_set_header X-Forwarded-Proto $thescheme;

### Documentation Changes Required
None?