### PR TITLE
Introduce interfaces for the application class chain

### DIFF
--- a/src/AbstractApplication.php
+++ b/src/AbstractApplication.php
@@ -19,7 +19,7 @@ use Psr\Log\NullLogger;
  *
  * @since  1.0
  */
-abstract class AbstractApplication implements LoggerAwareInterface
+abstract class AbstractApplication implements ConfigurationAwareApplicationInterface, LoggerAwareInterface
 {
 	/**
 	 * The application configuration object.

--- a/src/ApplicationInterface.php
+++ b/src/ApplicationInterface.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Part of the Joomla Framework Application Package
+ *
+ * @copyright  Copyright (C) 2005 - 2018 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Application;
+
+/**
+ * Joomla Framework Application Interface
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+interface ApplicationInterface
+{
+	/**
+	 * Method to close the application.
+	 *
+	 * @param   integer  $code  The exit code (optional; default is 0).
+	 *
+	 * @return  void
+	 *
+	 * @codeCoverageIgnore
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function close($code = 0);
+
+	/**
+	 * Execute the application.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function execute();
+}

--- a/src/ConfigurationAwareApplicationInterface.php
+++ b/src/ConfigurationAwareApplicationInterface.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Part of the Joomla Framework Application Package
+ *
+ * @copyright  Copyright (C) 2005 - 2018 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Application;
+
+use Joomla\Registry\Registry;
+
+/**
+ * Application sub-interface defining an application class which is aware of its configuration
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+interface ConfigurationAwareApplicationInterface extends ApplicationInterface
+{
+	/**
+	 * Returns a property of the object or the default value if the property is not set.
+	 *
+	 * @param   string  $key      The name of the property.
+	 * @param   mixed   $default  The default value (optional) if none is set.
+	 *
+	 * @return  mixed   The value of the configuration.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function get($key, $default = null);
+
+	/**
+	 * Modifies a property of the object, creating it if it does not already exist.
+	 *
+	 * @param   string  $key    The name of the property.
+	 * @param   mixed   $value  The value of the property to set (optional).
+	 *
+	 * @return  mixed   Previous value of the property
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function set($key, $value = null);
+
+	/**
+	 * Sets the configuration for the application.
+	 *
+	 * @param   Registry  $config  A registry object holding the configuration.
+	 *
+	 * @return  $this
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function setConfiguration(Registry $config);
+}


### PR DESCRIPTION
When implementing the `joomla/console` package, there are two pain points in the package's design:

- Inability to extend `Symfony\Component\Console\Application` (which basically mandates we have to have our own base Application and Command classes with no ability to use the upstream classes or anything that might be compatible with `symfony/console`)
- Proxying `joomla/input` into `Symfony\Component\Console\Input\InputInterface` which in effect means there are two copies of the input data floating around (one inside `Joomla\Input\Cli` which isn't really kept in sync and the `Joomla\Console\Input\JoomlaInput` class which is a subclass of `Symfony\Component\Console\Input\ArgvInput` and is really the main input data source in this context)

This PR addresses one of those pain points, being impossible to subclass the Symfony application class.  To do that, we need an interface for our own application and what capabilities need to be provided.  So, 2 interfaces are introduced: one for the main application's basic capability (execute it) and one for an application which is aware of your local configuration (if one even exists, assuming you can build a config-less system).  The `AbstractApplication` implements the new `ConfigurationAwareApplicationInterface` which satisfies all requirements, and lays the groundwork for being able to define root application capabilities (this is the closest thing we have a kernel in relation to other frameworks anyway) without requiring everything to extend a base class.