### PR TITLE
.editorconfig export-ignore

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,4 @@ Tests/ export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
 .phpunit.xml.dist export-ignore
+.editorconfig export-ignore


### PR DESCRIPTION
recently I contributed .ediorconfig to all framework packages..... well now those are merged to Joomla 4.0.2 its clear the .editorconfig is being exported when it should not be. 

This change will need to be made in all framework packages... maybe if I have time, or if you have time @nibra ? 

Started here as "a" for "application" was top of the list... 

Example of the problem:

<img width="494" alt="Screenshot 2021-09-07 at 21 20 55" src="https://user-images.githubusercontent.com/400092/132405873-216444ab-d7e6-42b3-8d1d-b3821fc36816.png">
