### PR TITLE
PHP 8.1 deprecation notices.

### DIFF
--- a/src/AbstractWebApplication.php
+++ b/src/AbstractWebApplication.php
@@ -882,6 +882,7 @@ abstract class AbstractWebApplication extends AbstractApplication implements Web
 		{
 			$code = 0;
 		}
+
 		header(str_replace(\chr(0), '', $string), $replace, $code);
 	}
 

--- a/src/AbstractWebApplication.php
+++ b/src/AbstractWebApplication.php
@@ -878,7 +878,7 @@ abstract class AbstractWebApplication extends AbstractApplication implements Web
 	 */
 	protected function header($string, $replace = true, $code = null)
 	{
-		if (is_null($code))
+		if ($code === null)
 		{
 			$code = 0;
 		}

--- a/src/AbstractWebApplication.php
+++ b/src/AbstractWebApplication.php
@@ -876,8 +876,12 @@ abstract class AbstractWebApplication extends AbstractApplication implements Web
 	 * @see     header()
 	 * @since   1.0
 	 */
-	protected function header($string, $replace = true, $code = 0)
+	protected function header($string, $replace = true, $code = null)
 	{
+		if (is_null($code))
+		{
+			$code = 0;
+		}
 		header(str_replace(\chr(0), '', $string), $replace, $code);
 	}
 

--- a/src/AbstractWebApplication.php
+++ b/src/AbstractWebApplication.php
@@ -876,7 +876,7 @@ abstract class AbstractWebApplication extends AbstractApplication implements Web
 	 * @see     header()
 	 * @since   1.0
 	 */
-	protected function header($string, $replace = true, $code = null)
+	protected function header($string, $replace = true, $code = 0)
 	{
 		header(str_replace(\chr(0), '', $string), $replace, $code);
 	}


### PR DESCRIPTION
Pull Request for Issue #

### Summary of Changes
Default response code should be integer.
Error message:
PHP Deprecated:  header(): Passing null to parameter #3 ($response_code) of type int is deprecated in D:\virtualhosts\clean40\libraries\vendor\joomla\application\src\AbstractWebApplication.php on line 881
### Testing Instructions
Code review or check that errors disappear from logfile.
### Documentation Changes Required
Probably not.