### PR TITLE
Application setHeader() does not respect $replace option

### DIFF
--- a/src/AbstractWebApplication.php
+++ b/src/AbstractWebApplication.php
@@ -571,6 +571,11 @@ abstract class AbstractWebApplication extends AbstractApplication implements Web
 			$response = $response->withoutHeader($name);
 		}
 
+		if (!$replace && $response->hasHeader($name))
+		{
+			return $this;
+		}
+		
 		// Add the header to the internal array.
 		$this->setResponse($response->withAddedHeader($name, $value));
 

--- a/src/AbstractWebApplication.php
+++ b/src/AbstractWebApplication.php
@@ -575,7 +575,7 @@ abstract class AbstractWebApplication extends AbstractApplication implements Web
 		{
 			return $this;
 		}
-		
+
 		// Add the header to the internal array.
 		$this->setResponse($response->withAddedHeader($name, $value));
 


### PR DESCRIPTION
The setHeader() method  causes the last header set to always be output even if $replace is set to false.

### Summary of Changes

Incorrect use of $replace causes the last value for a given header to always override pre-existing values, even if $replace is set to false.

### Testing Instructions

In any Joomla 4 version, use setHeader() similar to:

```
$app->setHeader('Some-Header', 'This should be used', true);
$app->setHeader('Some-Header', 'This should not be used', false);
```

Currently, the "Some-Header" header is set to "This should not be used" instead of "This should be used".

### Documentation Changes Required

None, bug fix.

