### PR TITLE
Improve bailouts detecting a web url

### DIFF
--- a/Tests/AbstractWebApplicationTest.php
+++ b/Tests/AbstractWebApplicationTest.php
@@ -1407,7 +1407,7 @@ class AbstractWebApplicationTest extends TestCase
     }
 
     /**
-     * @testdox       Tests that the application correcty detects the request URI based on the injected data
+     * @testdox       Tests that the application correctly detects the request URI based on the injected data
      *
      * @param  string|null  $https        Value for $_SERVER['HTTPS'] or null to not set it
      * @param  string       $phpSelf      Value for $_SERVER['PHP_SELF']
@@ -1453,6 +1453,34 @@ class AbstractWebApplicationTest extends TestCase
         );
     }
 
+    /**
+     * @testdox  Tests that the application correctly detects the request URI based on the injected data
+     *
+     * @param   string|null  $https        Value for $_SERVER['HTTPS'] or null to not set it
+     * @param   string       $phpSelf      Value for $_SERVER['PHP_SELF']
+     * @param   string       $requestUri   Value for $_SERVER['REQUEST_URI']
+     * @param   string       $httpHost     Value for $_SERVER['HTTP_HOST']
+     * @param   string       $scriptName   Value for $_SERVER['SCRIPT_NAME']
+     * @param   string       $queryString  Value for $_SERVER['QUERY_STRING']
+     * @param   string       $expects      Expected full URI string
+     *
+     * @covers  \Joomla\Application\AbstractWebApplication
+     *
+     * @backupGlobals enabled
+     */
+    public function testDetectRequestUriException()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $mockInput = new Input([]);
+
+        $_SERVER['PHP_SELF'] = 'somthing/framework.php';
+        $_SERVER['HTTP_HOST'] = '';
+        $_SERVER['SCRIPT_NAME'] = 'somthing/framework.php';
+
+        $object = $this->getMockForAbstractClass(AbstractWebApplication::class, [$mockInput]);
+
+        TestHelper::invoke($object, 'detectRequestUri');
+    }
     /**
      * @testdox  Tests the system URIs are correctly loaded when a URI is set in the application configuration
      *

--- a/Tests/AbstractWebApplicationTest.php
+++ b/Tests/AbstractWebApplicationTest.php
@@ -1454,7 +1454,7 @@ class AbstractWebApplicationTest extends TestCase
     }
 
     /**
-     * @testdox  Tests that the application correctly detects the request URI based on the injected data
+     * @testdox  Tests that the application throws an exception when there isn't a valid HTTP host.
      *
      * @param   string|null  $https        Value for $_SERVER['HTTPS'] or null to not set it
      * @param   string       $phpSelf      Value for $_SERVER['PHP_SELF']

--- a/src/AbstractWebApplication.php
+++ b/src/AbstractWebApplication.php
@@ -805,7 +805,7 @@ abstract class AbstractWebApplication extends AbstractApplication implements Web
 
         if ($httpHost === null)
         {
-            throw new \InvalidArgumentException('Unable to parse the hostname from the request');
+            throw new \InvalidArgumentException('Found an empty hostname when parsing the request');
         }
 
         // First we need to detect the URI scheme.

--- a/src/AbstractWebApplication.php
+++ b/src/AbstractWebApplication.php
@@ -803,8 +803,7 @@ abstract class AbstractWebApplication extends AbstractApplication implements Web
          */
         $httpHost = $this->input->server->getString('HTTP_HOST');
 
-        if ($httpHost === null)
-        {
+        if ($httpHost === null) {
             throw new \InvalidArgumentException('Found an empty hostname when parsing the request');
         }
 

--- a/src/AbstractWebApplication.php
+++ b/src/AbstractWebApplication.php
@@ -793,9 +793,21 @@ abstract class AbstractWebApplication extends AbstractApplication implements Web
      * @return  string  The requested URI
      *
      * @since   1.0.0
+     * @throws  \InvalidArgumentException
      */
     protected function detectRequestUri()
     {
+        /**
+         * If we've arrived here via a CLI application (which shouldn't happen in our web app) then we can use this as
+         * an opportunity to bail out
+         */
+        $httpHost = $this->input->server->getString('HTTP_HOST');
+
+        if ($httpHost === null)
+        {
+            throw new \InvalidArgumentException('Unable to parse the hostname from the request');
+        }
+
         // First we need to detect the URI scheme.
         $scheme = $this->isSslConnection() ? 'https://' : 'http://';
 
@@ -808,7 +820,7 @@ abstract class AbstractWebApplication extends AbstractApplication implements Web
         $phpSelf    = $this->input->server->getString('PHP_SELF', '');
         $requestUri = $this->input->server->getString('REQUEST_URI', '');
 
-        $uri = $scheme . $this->input->server->getString('HTTP_HOST');
+        $uri = $scheme . $httpHost;
 
         if (!empty($phpSelf) && !empty($requestUri)) {
             // If PHP_SELF and REQUEST_URI are both populated then we will assume "Apache Mode".


### PR DESCRIPTION
Improves error handling in cases such as https://github.com/joomla/joomla-cms/pull/38524 where we boot a web application from the cli. Clearly in this case we shouldn't try and form a mis-shaped URL. And from a framework perspective - if we can't find a host then it likely makes sense to bail early rather than miss a domain in a web app's primary url

### Summary of Changes
So none of the tests actually have a http host. so most fail where we create a concrete instance. But in a way that shows how our behaviour is kinda unexpected. Should we fail if we can't parse a url. or try and continue. if we try and continue should we set these properties??

### Testing Instructions
Code Review

### Documentation Changes Required
Not really
