### PR TITLE
remove pragma header

### DIFF
--- a/src/AbstractWebApplication.php
+++ b/src/AbstractWebApplication.php
@@ -371,7 +371,7 @@ abstract class AbstractWebApplication extends AbstractApplication implements Web
             $this->setHeader('Content-Type', $this->mimeType . '; charset=' . $this->charSet);
         }
 
-        // If the response is set to uncachable, et some appropriate headers so browsers don't cache the response.
+        // If the response is set to uncachable, set some appropriate headers so browsers don't cache the response.
         if (!$this->allowCache()) {
             // Expires in the past.
             $this->setHeader('Expires', 'Wed, 17 Aug 2005 00:00:00 GMT', true);
@@ -380,8 +380,6 @@ abstract class AbstractWebApplication extends AbstractApplication implements Web
             $this->setHeader('Last-Modified', \gmdate('D, d M Y H:i:s') . ' GMT', true);
             $this->setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, post-check=0, pre-check=0', false);
 
-            // HTTP 1.0
-            $this->setHeader('Pragma', 'no-cache');
         } else {
             // Expires.
             if (!$this->getResponse()->hasHeader('Expires')) {


### PR DESCRIPTION
## Summary of Changes
Pragma is a HTTP/1.0 header. In HTTP/1.1, Pragma is deprecated and superseded by the Cache-Control header. Remove Pragma to save bandwidth and processing power and it doesn't do anything as it is used after the cache-control header (this was by design to support http/1.0 headers a decade ago)

Mozilla telemetry indicates that there is less than 0.24% still using 1.0 https://mzl.la/3tFMtkA

httparchive didnt even include 1.0 in its 2020 almanac https://almanac.httparchive.org/en/2020/http#fig-3 but in 2019 they reported less than 0.06%

Pull Request for Issue #

### Summary of Changes

### Testing Instructions

### Documentation Changes Required
