### PR TITLE
Deprecating X-Content-Encoded-By

### DIFF
--- a/Tests/AbstractWebApplicationTest.php
+++ b/Tests/AbstractWebApplicationTest.php
@@ -376,7 +376,6 @@ class AbstractWebApplicationTest extends TestCase
             [
                 0 => ['name' => 'Content-Encoding', 'value' => 'gzip'],
                 1 => ['name' => 'Vary', 'value' => 'Accept-Encoding'],
-                2 => ['name' => 'X-Content-Encoded-By', 'value' => 'Joomla'],
             ],
             $object->getHeaders()
         );
@@ -447,7 +446,6 @@ class AbstractWebApplicationTest extends TestCase
             [
                 0 => ['name' => 'Content-Encoding', 'value' => 'deflate'],
                 1 => ['name' => 'Vary', 'value' => 'Accept-Encoding'],
-                2 => ['name' => 'X-Content-Encoded-By', 'value' => 'Joomla'],
             ],
             $object->getHeaders()
         );

--- a/src/AbstractWebApplication.php
+++ b/src/AbstractWebApplication.php
@@ -345,7 +345,6 @@ abstract class AbstractWebApplication extends AbstractApplication implements Web
                 // Set the encoding headers.
                 $this->setHeader('Content-Encoding', $encoding);
                 $this->setHeader('Vary', 'Accept-Encoding');
-                $this->setHeader('X-Content-Encoded-By', 'Joomla');
 
                 // Replace the output with the encoded data.
                 $this->setBody($gzdata);


### PR DESCRIPTION
X-Content-Encode-By header has been deprecated since 2013 : https://github.com/joomla/joomla-cms/pull/1233

### Summary of Changes

Delete one line

### Testing Instructions
Call any Joomla website where GZIP option is set in https://securityheaders.com/ 

Before this PR, a line x-content-encoded-by  Joomla appears.
After applying this PR, this line disappears.