### PR TITLE
Respect the replace flag for Headers

### DIFF
--- a/src/AbstractWebApplication.php
+++ b/src/AbstractWebApplication.php
@@ -553,6 +553,11 @@ abstract class AbstractWebApplication extends AbstractApplication implements Web
         $value    = (string) $value;
         $response = $this->getResponse();
 
+        // Don't override if the header exists
+        if (!$replace && $response->hasHeader($name)) {
+            return $this;
+        }
+
         // If the replace flag is set, unset all known headers with the given name.
         if ($replace && $response->hasHeader($name)) {
             $response = $response->withoutHeader($name);


### PR DESCRIPTION
Pull Request for Issue 

### Summary of Changes

If the replace flag is false the code should bail out!

### Testing Instructions

Assuming applying the changes in the Joomla-cms:

add `$app->setHeader('Cache-Control', 'no-cache, must-revalidate', true);` in the cassiopeia after the line `$app   = Factory::getApplication();`

Check the Headers

### Documentation Changes Required
Nope, this is a bug