### PR TITLE
[PHP8.4] Deprecate implicitly nullable parameter types

### DIFF
--- a/Tests/Controller/ContainerControllerResolverTest.php
+++ b/Tests/Controller/ContainerControllerResolverTest.php
@@ -8,12 +8,9 @@
 namespace Joomla\Application\Tests\Controller;
 
 use Joomla\Application\Controller\ContainerControllerResolver;
-use Joomla\Application\Controller\ControllerResolver;
-use Joomla\Application\Event\ApplicationEvent;
 use Joomla\Application\Tests\Stubs\Controller;
 use Joomla\Application\Tests\Stubs\HasArgumentsController;
 use Joomla\DI\Container;
-use Joomla\Registry\Registry;
 use Joomla\Router\ResolvedRoute;
 use PHPUnit\Framework\TestCase;
 

--- a/Tests/Controller/ControllerResolverTest.php
+++ b/Tests/Controller/ControllerResolverTest.php
@@ -8,7 +8,6 @@
 namespace Joomla\Application\Tests\Controller;
 
 use Joomla\Application\Controller\ControllerResolver;
-use Joomla\Application\Event\ApplicationEvent;
 use Joomla\Application\Tests\Stubs\Controller;
 use Joomla\Application\Tests\Stubs\HasArgumentsController;
 use Joomla\Registry\Registry;

--- a/Tests/SessionAwareWebApplicationTraitTest.php
+++ b/Tests/SessionAwareWebApplicationTraitTest.php
@@ -8,7 +8,6 @@
 namespace Joomla\Application\Tests;
 
 use Joomla\Application\SessionAwareWebApplicationTrait;
-use Joomla\Application\WebApplication;
 use Joomla\Input\Input;
 use Joomla\Session\SessionInterface;
 use PHPUnit\Framework\TestCase;

--- a/Tests/Web/WebClientTest.php
+++ b/Tests/Web/WebClientTest.php
@@ -7,7 +7,6 @@
 
 namespace Joomla\Application\Tests\Web;
 
-use Joomla\Application\Tests\CompatTestCase;
 use Joomla\Application\Web\WebClient;
 use PHPUnit\Framework\TestCase;
 

--- a/rector.php
+++ b/rector.php
@@ -2,10 +2,8 @@
 
 declare(strict_types=1);
 
-use Rector\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector;
 use Rector\Config\RectorConfig;
 use Rector\Php71\Rector\ClassConst\PublicConstantVisibilityRector;
-use Rector\Set\ValueObject\LevelSetList;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->paths([

--- a/src/AbstractApplication.php
+++ b/src/AbstractApplication.php
@@ -51,7 +51,7 @@ abstract class AbstractApplication implements
      *
      * @since   1.0.0
      */
-    public function __construct(Registry $config = null)
+    public function __construct(?Registry $config = null)
     {
         $this->config = $config ?: new Registry();
 

--- a/src/AbstractWebApplication.php
+++ b/src/AbstractWebApplication.php
@@ -191,10 +191,10 @@ abstract class AbstractWebApplication extends AbstractApplication implements Web
      * @since   1.0.0
      */
     public function __construct(
-        Input $input = null,
-        Registry $config = null,
-        WebClient $client = null,
-        ResponseInterface $response = null
+        ?Input $input = null,
+        ?Registry $config = null,
+        ?WebClient $client = null,
+        ?ResponseInterface $response = null
     ) {
         $this->input  = $input ?: new Input();
         $this->client = $client ?: new WebClient();

--- a/src/WebApplication.php
+++ b/src/WebApplication.php
@@ -46,22 +46,22 @@ class WebApplication extends AbstractWebApplication implements SessionAwareWebAp
      *
      * @param  ControllerResolverInterface  $controllerResolver   The application's controller resolver
      * @param  RouterInterface              $router               The application's router
-     * @param  Input                        ?$input               An optional argument to provide dependency injection
+     * @param  Input|null                   $input                An optional argument to provide dependency injection
      *                                                            for the application's input object.  If the argument
      *                                                            is an Input object that object will become the
      *                                                            application's input object, otherwise a default input
      *                                                            object is created.
-     * @param  Registry                     ?$config              An optional argument to provide dependency injection
+     * @param  Registry|null                $config               An optional argument to provide dependency injection
      *                                                            for the application's config object.  If the argument
      *                                                            is a Registry object that object will become the
      *                                                            application's config object, otherwise a default
      *                                                            config object is created.
-     * @param  Web\WebClient                ?$client              An optional argument to provide dependency injection
+     * @param  WebClient|null               $client               An optional argument to provide dependency injection
      *                                                            for the application's client object.  If the argument
      *                                                            is a Web\WebClient object that object will become the
      *                                                            application's client object, otherwise a default
      *                                                            client object is created.
-     * @param  ResponseInterface            ?$response            An optional argument to provide dependency injection
+     * @param  ResponseInterface|null       $response             An optional argument to provide dependency injection
      *                                                            for the application's response object.  If the
      *                                                            argument is a ResponseInterface object that object
      *                                                            will become the application's response object,
@@ -72,10 +72,10 @@ class WebApplication extends AbstractWebApplication implements SessionAwareWebAp
     public function __construct(
         ControllerResolverInterface $controllerResolver,
         RouterInterface $router,
-        Input $input = null,
-        Registry $config = null,
-        WebClient $client = null,
-        ResponseInterface $response = null
+        ?Input $input = null,
+        ?Registry $config = null,
+        ?WebClient $client = null,
+        ?ResponseInterface $response = null
     ) {
         $this->controllerResolver = $controllerResolver;
         $this->router             = $router;


### PR DESCRIPTION
### Summary of Changes

updates for [Deprecate implicitly nullable parameter types](https://wiki.php.net/rfc/deprecate-implicitly-nullable-types)

### Testing Instructions

code review

### Documentation Changes Required

no