### PR TITLE
[3.x] Fix browser and engine detection of web client

### DIFF
--- a/Tests/Web/WebClientTest.php
+++ b/Tests/Web/WebClientTest.php
@@ -350,6 +350,14 @@ class WebClientTest extends TestCase
                 '75.0.107.0',
                 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3738.0 Safari/537.36 Edg/75.0.107.0',
             ],
+            [
+                '',
+                false,
+                WebClient::BLINK,
+                WebClient::CHROME,
+                '',
+                'Chrome Privacy Preserving Prefetch Proxy',
+            ],
         ];
     }
 

--- a/Tests/Web/WebClientTest.php
+++ b/Tests/Web/WebClientTest.php
@@ -31,6 +31,14 @@ class WebClientTest extends TestCase
         // Platform, Mobile, Engine, Browser, Version, User Agent
         return [
             [
+                '',
+                false,
+                '',
+                '',
+                '',
+                null,
+            ],
+            [
                 WebClient::WINDOWS,
                 false,
                 WebClient::TRIDENT,

--- a/Tests/Web/WebClientTest.php
+++ b/Tests/Web/WebClientTest.php
@@ -159,6 +159,14 @@ class WebClientTest extends TestCase
                 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.71 Safari/537.36',
             ],
             [
+                WebClient::WINDOWS,
+                false,
+                WebClient::BLINK,
+                WebClient::CHROME,
+                '131.0.0.0',
+                'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
+            ],
+            [
                 WebClient::LINUX,
                 false,
                 WebClient::WEBKIT,

--- a/Tests/Web/WebClientTest.php
+++ b/Tests/Web/WebClientTest.php
@@ -366,6 +366,22 @@ class WebClientTest extends TestCase
                 '',
                 'Chrome Privacy Preserving Prefetch Proxy',
             ],
+            [
+                '',
+                false,
+                WebClient::BLINK,
+                WebClient::CHROME,
+                '',
+                'Chrome',
+            ],
+            [
+                '',
+                false,
+                WebClient::WEBKIT,
+                '',
+                '',
+                'AppleWebKit',
+            ],
         ];
     }
 

--- a/Tests/Web/WebClientTest.php
+++ b/Tests/Web/WebClientTest.php
@@ -382,6 +382,14 @@ class WebClientTest extends TestCase
                 '',
                 'AppleWebKit',
             ],
+            [
+                '',
+                false,
+                WebClient::BLINK,
+                '',
+                '',
+                'AppleWebKit/537.36',
+            ],
         ];
     }
 

--- a/src/Web/WebClient.php
+++ b/src/Web/WebClient.php
@@ -342,8 +342,8 @@ class WebClient
                     if ($key) {
                         $this->browserVersion = $matches['version'][$key];
                     }
-                } elseif ($matches['version'][0] !== 'Privacy') {
-                    // We only have a Version or a browser so use what we have.
+                } elseif ($this->browser !== self::CHROME || $matches['version'][0] !== 'Privacy') {
+                    // We only have a Version or a browser so use what we have if not Google privacy prefetch proxy.
                     $this->browserVersion = $matches['version'][0];
                 }
             }

--- a/src/Web/WebClient.php
+++ b/src/Web/WebClient.php
@@ -395,9 +395,9 @@ class WebClient
             $this->engine = self::BLINK;
         } elseif (\stripos($userAgent, 'Chrome') !== false) {
             $result  = \explode('/', \stristr($userAgent, 'Chrome'));
-            $version = \explode(' ', $result[1]);
+            $version = \count($result) > 1 ? \explode(' ', $result[1]) : false;
 
-            if ($version[0] >= 28) {
+            if ($version === false || $version[0] >= 28) {
                 $this->engine = self::BLINK;
             } else {
                 $this->engine = self::WEBKIT;
@@ -405,9 +405,9 @@ class WebClient
         } elseif (\stripos($userAgent, 'AppleWebKit') !== false || \stripos($userAgent, 'blackberry') !== false) {
             if (\stripos($userAgent, 'AppleWebKit') !== false) {
                 $result  = \explode('/', \stristr($userAgent, 'AppleWebKit'));
-                $version = \explode(' ', $result[1]);
+                $version = \count($result) > 1 ? \explode(' ', $result[1]) : false;
 
-                if ($version[0] === 537.36) {
+                if ($version !== false && $version[0] === 537.36) {
                     // AppleWebKit/537.36 is Blink engine specific, exception is Blink emulated IEMobile, Trident or Edge
                     $this->engine = self::BLINK;
                 }

--- a/src/Web/WebClient.php
+++ b/src/Web/WebClient.php
@@ -409,7 +409,7 @@ class WebClient
             if (isset($result[1])) {
                 $version = \explode(' ', $result[1]);
 
-                if ($version[0] < 28) {
+                if (version_compare($version[0], '28.0', 'lt')) {
                     $this->engine = self::WEBKIT;
                 }
             }

--- a/src/Web/WebClient.php
+++ b/src/Web/WebClient.php
@@ -422,7 +422,7 @@ class WebClient
                 if (isset($result[1])) {
                     $version = \explode(' ', $result[1]);
 
-                    if ($version[0] === 537.36) {
+                    if ($version[0] === '537.36') {
                         // AppleWebKit/537.36 is Blink engine specific, exception is Blink emulated IEMobile, Trident or Edge
                         $this->engine = self::BLINK;
                     }

--- a/src/Web/WebClient.php
+++ b/src/Web/WebClient.php
@@ -402,27 +402,32 @@ class WebClient
         } elseif (\stripos($userAgent, 'Edg') !== false) {
             $this->engine = self::BLINK;
         } elseif (\stripos($userAgent, 'Chrome') !== false) {
-            $result  = \explode('/', \stristr($userAgent, 'Chrome'));
-            $version = isset($result[1]) ? \explode(' ', $result[1]) : false;
+            $this->engine = self::BLINK;
 
-            if ($version === false || $version[0] >= 28) {
-                $this->engine = self::BLINK;
-            } else {
-                $this->engine = self::WEBKIT;
-            }
-        } elseif (\stripos($userAgent, 'AppleWebKit') !== false || \stripos($userAgent, 'blackberry') !== false) {
-            if (\stripos($userAgent, 'AppleWebKit') !== false) {
-                $result  = \explode('/', \stristr($userAgent, 'AppleWebKit'));
-                $version = isset($result[1]) ? \explode(' ', $result[1]) : false;
+            $result = \explode('/', \stristr($userAgent, 'Chrome'));
 
-                if ($version !== false && $version[0] === 537.36) {
-                    // AppleWebKit/537.36 is Blink engine specific, exception is Blink emulated IEMobile, Trident or Edge
-                    $this->engine = self::BLINK;
+            if (isset($result[1])) {
+                $version = \explode(' ', $result[1]);
+
+                if ($version[0] < 28) {
+                    $this->engine = self::WEBKIT;
                 }
             }
-
-            // Evidently blackberry uses WebKit and doesn't necessarily report it.  Bad RIM.
+        } elseif (\stripos($userAgent, 'AppleWebKit') !== false || \stripos($userAgent, 'blackberry') !== false) {
             $this->engine = self::WEBKIT;
+
+            if (\stripos($userAgent, 'AppleWebKit') !== false) {
+                $result = \explode('/', \stristr($userAgent, 'AppleWebKit'));
+
+                if (isset($result[1])) {
+                    $version = \explode(' ', $result[1]);
+
+                    if ($version[0] === 537.36) {
+                        // AppleWebKit/537.36 is Blink engine specific, exception is Blink emulated IEMobile, Trident or Edge
+                        $this->engine = self::BLINK;
+                    }
+                }
+            }
         } elseif (\stripos($userAgent, 'Gecko') !== false && \stripos($userAgent, 'like Gecko') === false) {
             // We have to check for like Gecko because some other browsers spoof Gecko.
             $this->engine = self::GECKO;

--- a/src/Web/WebClient.php
+++ b/src/Web/WebClient.php
@@ -395,7 +395,7 @@ class WebClient
             $this->engine = self::BLINK;
         } elseif (\stripos($userAgent, 'Chrome') !== false) {
             $result  = \explode('/', \stristr($userAgent, 'Chrome'));
-            $version = \count($result) > 1 ? \explode(' ', $result[1]) : false;
+            $version = isset($result[1]) ? \explode(' ', $result[1]) : false;
 
             if ($version === false || $version[0] >= 28) {
                 $this->engine = self::BLINK;
@@ -405,7 +405,7 @@ class WebClient
         } elseif (\stripos($userAgent, 'AppleWebKit') !== false || \stripos($userAgent, 'blackberry') !== false) {
             if (\stripos($userAgent, 'AppleWebKit') !== false) {
                 $result  = \explode('/', \stristr($userAgent, 'AppleWebKit'));
-                $version = \count($result) > 1 ? \explode(' ', $result[1]) : false;
+                $version = isset($result[1]) ? \explode(' ', $result[1]) : false;
 
                 if ($version !== false && $version[0] === 537.36) {
                     // AppleWebKit/537.36 is Blink engine specific, exception is Blink emulated IEMobile, Trident or Edge

--- a/src/Web/WebClient.php
+++ b/src/Web/WebClient.php
@@ -290,7 +290,7 @@ class WebClient
         // Check for Google's Private Prefetch Proxy
         if ($userAgent === 'Chrome Privacy Preserving Prefetch Proxy') {
             // Private Prefetch Proxy does not provide any further details like e.g. version
-            $this->browser  = self::CHROME;
+            $this->browser = self::CHROME;
 
             return;
         }

--- a/src/Web/WebClient.php
+++ b/src/Web/WebClient.php
@@ -287,6 +287,14 @@ class WebClient
             return;
         }
 
+        // Check for Google's Private Prefetch Proxy
+        if ($userAgent === 'Chrome Privacy Preserving Prefetch Proxy') {
+            // Private Prefetch Proxy does not provide any further details like e.g. version
+            $this->browser  = self::CHROME;
+
+            return;
+        }
+
         $patternBrowser = '';
 
         // Attempt to detect the browser type.  Obviously we are only worried about major browsers.
@@ -342,8 +350,8 @@ class WebClient
                     if ($key) {
                         $this->browserVersion = $matches['version'][$key];
                     }
-                } elseif ($this->browser !== self::CHROME || $matches['version'][0] !== 'Privacy') {
-                    // We only have a Version or a browser so use what we have if not Google privacy prefetch proxy.
+                } else {
+                    // We only have a Version or a browser so use what we have.
                     $this->browserVersion = $matches['version'][0];
                 }
             }

--- a/src/Web/WebClient.php
+++ b/src/Web/WebClient.php
@@ -342,7 +342,7 @@ class WebClient
                     if ($key) {
                         $this->browserVersion = $matches['version'][$key];
                     }
-                } else {
+                } elseif ($matches['version'][0] !== 'Privacy') {
                     // We only have a Version or a browser so use what we have.
                     $this->browserVersion = $matches['version'][0];
                 }


### PR DESCRIPTION
Pull Request for Issue #112 

### Summary of Changes

This pull request (PR) fixes diverse bugs in the browser and engine detection of the web client.

First of all it adds a check if a version part was found in the `$userAgent` parameter at 2 places in the "detectEngine" method of web client in order not to run into a PHP error "Undefined array key 1" when a known user agent is used without a version part.

See the linked issue and another CMS issue https://github.com/joomla/joomla-cms/issues/44469 .

In addition, it adds a check for user agent = "Chrome Privacy Preserving Prefetch Proxy" to the "detectBrowser" method to make sure that no wrong version is detected, and it adds a unit test case for that user agent and for user agents without a version where we would have run into the "Undefined array key 1" error.

The user agent "Chrome Privacy Preserving Prefetch Proxy" is used by the https://developer.chrome.com/blog/private-prefetch-proxy and does not provide any further information like e.g. a version.

The Privacy Preserving Prefetch Proxy is a feature which Google gradually roll out on their Chrome browsers. It allows the prefetching of cross-origin content without exposing user information to the destination website.

That means when you see previews of websites in search results, your user agent will not be exposed to the website where this preview comes from until you navigate to that website. That's the case where the PHP warnings mentioned in the referred issue and CMS issues happen, which is fixed by this PR here.

In addition, this PR fixes the wrong check `$version[0] === 537.36` for "AppleWebKit/537.36" which should be `$version[0] === '537.36'` in the "detectEngine" method and adds a test case for that because existing test cases for real user agents did not cover that case.

Last but not least, this PR fixes the wrong check `$version[0] < 28` for Google Chrome, which works well with the existing test case for version "54.0.2840.71" but not for a current version > 99 like e.g. "131.0.0.0". The fix is to use version_compare, which works regardless of how many dots you have in a version, and this PR adds a new test data set for that.

Finally, this PR adds a text case for the issue #114 fixed with PR #131 .

### Testing Instructions

#### Prepare testing environment

On a development environment (Linux computer or Windows with WSL, with composer and a git client), clone the joomla-framework/application repository into a local folder and prepare for running unit tests on the default branch `3.x-dev`:

```
mkdir test-pr-132
cd test-pr-132
git clone https://github.com/joomla-framework/application.git .
composer update --prefer-stable
```

Check that unit tests succeed on your environment:
```
vendor/bin/phpunit --testdox
```
Result:
```
OK (213 tests, 373 assertions)
```

#### Add new unit tests from this PR and check failing test cases

Now apply only the changes in file `Tests/Web/WebClientTest.php` from this PR, e.g. by downloading the file from the raw view on GiHub:
https://raw.githubusercontent.com/joomla-framework/application/df5fc53c3e15817c6449e372ed415e9ab95530b9/Tests/Web/WebClientTest.php

Do **_not_** apply the changes from file `src/Web/WebClient.php` from this PR.

Run unit tests:
```
vendor/bin/phpunit --testdox
```
Results:
- Detect browser fails for the new data set no. 42 with user agent "Chrome Privacy Preserving Prefetch Proxy" because it detects a wrong version "Privacy".
```
 ✘ Detect browser with data set #42
   │
   │ Version detection failed
   │ Failed asserting that two strings are equal.
   │ --- Expected
   │ +++ Actual
   │ @@ @@
   │ -'Privacy'
   │ +''
   │
   │ /home/richard/GitHub/joomla-framework/application/Tests/Web/WebClientTest.php:525
   │
```
- Detect engine fails for the new data set no. 16 with the user agent of a Google Chrome version 131.0.0.0 because of the wrong check for version < 28, so it detects engine `WebClient::WEBKIT` instead of `WebClient::BLINK`.
```
 ✘ Detect engine with data set #16
   │
   │ Engine detection failed.
   │ Failed asserting that 24 matches expected 12.
   │
   │ /home/richard/GitHub/joomla-framework/application/Tests/Web/WebClientTest.php:589
   │
```
- Detect engine fails for the new data set no. 42 with user agent "Chrome Privacy Preserving Prefetch Proxy" because it detects engine `WebClient::WEBKIT` instead of `WebClient::BLINK`.
```
 ✘ Detect engine with data set #42
   │
   │ Engine detection failed.
   │ Failed asserting that 24 matches expected 12.
   │
   │ /home/richard/GitHub/joomla-framework/application/Tests/Web/WebClientTest.php:589
   │
```
- Detect engine fails for the new data set no. 43 with user agent "Chrome" without any version because because it detects engine `WebClient::WEBKIT` instead of `WebClient::BLINK`.
```
 ✘ Detect engine with data set #43
   │
   │ Engine detection failed.
   │ Failed asserting that 24 matches expected 12.
   │
   │ /home/richard/GitHub/joomla-framework/application/Tests/Web/WebClientTest.php:589
   │
```
- Detect engine fails for the new data set no. 44 with user agent "AppleWebKit" without any version with a PHP notice.
```
 ⚠ Detect engine with data set #44
```
- Detect engine fails for the new data set no. 45 with user agent "'AppleWebKit/537.36" because it detects engine `WebClient::WEBKIT` instead of `WebClient::BLINK` due to the wrong check `$version[0] === 537.36` which should be `$version[0] === '537.36'`.
```
 ✘ Detect engine with data set #45
   │
   │ Engine detection failed.
   │ Failed asserting that 24 matches expected 12.
   │
   │ /home/richard/GitHub/joomla-framework/application/Tests/Web/WebClientTest.php:589
   │
```
- Overall result:
```
FAILURES!
Tests: 231, Assertions: 403, Failures: 5, Warnings: 2.
Remaining self deprecation notices (3)
```

#### Run unit tests on the code changes from this PR

Now apply also the changes from file `src/Web/WebClient.php` from this PR, e.g. by downloading the file from the raw view on GiHub:
https://raw.githubusercontent.com/joomla-framework/application/df5fc53c3e15817c6449e372ed415e9ab95530b9/src/Web/WebClient.php

Run unit tests:
```
vendor/bin/phpunit --testdox
```
Result:
```
OK (231 tests, 403 assertions)
```

### Documentation Changes Required

None as far as I know.