### PR TITLE
[4.0] Updating dependencies to next major version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,21 +37,21 @@
     "require": {
         "php": "^8.1.0",
         "psr/log": "^1.0|^2.0|^3.0",
-        "psr/http-message": "^1.0",
-        "joomla/event": "^3.0",
-        "joomla/registry": "^3.0",
-        "laminas/laminas-diactoros": "^2.24.0",
+        "psr/http-message": "^2.0",
+        "joomla/event": "dev-4.x-dev",
+        "joomla/registry": "dev-4.x-dev",
+        "laminas/laminas-diactoros": "^3.6.0",
         "symfony/deprecation-contracts": "^2|^3"
     },
     "require-dev": {
         "ext-json": "*",
-        "joomla/controller": "^3.0",
-        "joomla/di": "^3.0",
-        "joomla/input": "^3.0",
-        "joomla/router": "^3.0",
-        "joomla/session": "^3.0",
-        "joomla/test": "^3.0",
-        "joomla/uri": "^3.0",
+        "joomla/controller": "dev-4.x-dev",
+        "joomla/di": "dev-4.x-dev",
+        "joomla/input": "dev-4.x-dev",
+        "joomla/router": "dev-4.x-dev",
+        "joomla/session": "dev-4.x-dev",
+        "joomla/test": "dev-4.x-dev",
+        "joomla/uri": "dev-4.x-dev",
         "phpunit/phpunit": "^10.0",
         "symfony/phpunit-bridge": "^7.0",
         "squizlabs/php_codesniffer": "~3.10.2",
@@ -60,12 +60,12 @@
     },
     "suggest": {
         "ext-json": "To use JSON format, ext-json is required",
-        "joomla/controller": "^3.0 To support resolving ControllerInterface objects in ControllerResolverInterface, install joomla/controller",
-        "joomla/input": "^3.0 To use WebApplicationInterface, install joomla/input",
-        "joomla/router": "^3.0 To use WebApplication or ControllerResolverInterface implementations, install joomla/router",
-        "joomla/session": "^3.0 To use SessionAwareWebApplicationInterface, install joomla/session",
-        "joomla/uri": "^3.0 To use AbstractWebApplication, install joomla/uri",
-        "psr/container": "^1.0 To use the ContainerControllerResolver, install any PSR-11 compatible container"
+        "joomla/controller": "^4.0 To support resolving ControllerInterface objects in ControllerResolverInterface, install joomla/controller",
+        "joomla/input": "^4.0 To use WebApplicationInterface, install joomla/input",
+        "joomla/router": "^4.0 To use WebApplication or ControllerResolverInterface implementations, install joomla/router",
+        "joomla/session": "^4.0 To use SessionAwareWebApplicationInterface, install joomla/session",
+        "joomla/uri": "^4.0 To use AbstractWebApplication, install joomla/uri",
+        "psr/container": "^2.0 To use the ContainerControllerResolver, install any PSR-11 compatible container"
     },
     "autoload": {
         "psr-4": {
@@ -83,10 +83,6 @@
         "test": "vendor/bin/phpunit",
         "testdox": "vendor/bin/phpunit --testdox",
         "coverage": "vendor/bin/phpunit --coverage-html build/coverage",
-        "sign": [
-            "drone jsonnet --stream",
-            "drone sign joomla-framework/application --save"
-        ],
         "style": [
             "vendor/bin/phpcbf --report=full --extensions=php --standard=PSR12 src/",
             "vendor/bin/phpcs --report=full --extensions=php --standard=PSR12 src/"
@@ -96,13 +92,13 @@
         "test": "Run the PHPUnit tests",
         "testdox": "Run the PHPUnit tests and output the result in testdox format",
         "coverage": "Run the PHPUnit tests and write an HTML coverage report to build/coverage",
-        "sign": "Compile .drone.jsonnet and sign the resulting YML file. Make sure to have set DRONE_SERVER and DRONE_TOKEN properly.",
         "style": "Fix any style issues that can be fixed automatically and run a check afterwards to list issues that could not be solved."
     },
     "extra": {
         "branch-alias": {
             "dev-2.0-dev": "2.0-dev",
-            "dev-3.x-dev": "3.0-dev"
+            "dev-3.x-dev": "3.0-dev",
+            "dev-4.x-dev": "4.0-dev"
         }
     }
 }


### PR DESCRIPTION
### Summary of Changes
This updates the dependencies each to the latest major version. It especially updates the Joomla framework packages to the latest 4.x-dev version for development purposes. When everything is ready, we will have to switch it to `^4.0` again. Since we are moving to Github Actions, I also removed the references to Drone CI.