### PR TITLE
[4.x] Revert AbstractWebApplication magic getter removal

### DIFF
--- a/docs/v3-to-v4-update.md
+++ b/docs/v3-to-v4-update.md
@@ -6,18 +6,6 @@ The following changes were made to the Application package between v3 and v4.
 
 All Framework packages now require PHP 8.3 or newer.
 
-### Access to input data
-
-Accessing the input data in the input attribute of the application can now only be done via the `getInput()`.
-
-```php
-// Old
-$app->input->getInt();
-
-// New
-$app->getInput()->getInt();
-```
-
 ### Status on redirect
 
 When calling `$app->redirect()`, you can not hand over a boolean value for the status, but always have to use an integer representing the HTTP status code.

--- a/src/AbstractWebApplication.php
+++ b/src/AbstractWebApplication.php
@@ -214,6 +214,46 @@ abstract class AbstractWebApplication extends AbstractApplication implements Web
     }
 
     /**
+     * Magic method to access properties of the application.
+     *
+     * @param  string  $name  The name of the property.
+     *
+     * @return Input|null A value if the property name is valid, null otherwise.
+     *
+     * @since       2.0.0
+     * @deprecated  3.0  This is a B/C proxy for deprecated read accesses
+     */
+    public function __get($name)
+    {
+        switch ($name) {
+            case 'input':
+                \trigger_deprecation(
+                    'joomla/application',
+                    '2.0.0',
+                    'Accessing the input property of %s is deprecated, use the %s::getInput() method instead.',
+                    self::class,
+                    self::class
+                );
+
+                return $this->getInput();
+
+            default:
+                $trace = \debug_backtrace();
+                \trigger_error(
+                    \sprintf(
+                        'Undefined property via __get(): %1$s in %2$s on line %3$s',
+                        $name,
+                        $trace[0]['file'],
+                        $trace[0]['line']
+                    ),
+                    E_USER_NOTICE
+                );
+
+                return null;
+        }
+    }
+
+    /**
      * Execute the application.
      *
      * @return  void


### PR DESCRIPTION
Pull Request for CMS issues https://github.com/joomla/joomla-cms/issues/45996 and https://github.com/joomla/joomla-cms/issues/45946

### Summary of Changes

This pull request (PR) partially reverts PR #137 by adding back the magic getter method for the inpout property of the AbstractWebApplication.

### Testing Instructions

See CMS issues https://github.com/joomla/joomla-cms/issues/45996 and https://github.com/joomla/joomla-cms/issues/45946 . 

### Documentation Changes Required

None besides the one changed by this PR.