### PR TITLE
Remove no-store for Cache-Control

### DIFF
--- a/src/AbstractWebApplication.php
+++ b/src/AbstractWebApplication.php
@@ -377,7 +377,7 @@ abstract class AbstractWebApplication extends AbstractApplication implements Web
 
             // Always modified.
             $this->setHeader('Last-Modified', \gmdate('D, d M Y H:i:s') . ' GMT', true);
-            $this->setHeader('Cache-Control', 'no-cache, must-revalidate, post-check=0, pre-check=0', false);
+            $this->setHeader('Cache-Control', 'no-cache, must-revalidate', false);
 
             // HTTP 1.0
             $this->setHeader('Pragma', 'no-cache');

--- a/src/AbstractWebApplication.php
+++ b/src/AbstractWebApplication.php
@@ -377,7 +377,7 @@ abstract class AbstractWebApplication extends AbstractApplication implements Web
 
             // Always modified.
             $this->setHeader('Last-Modified', \gmdate('D, d M Y H:i:s') . ' GMT', true);
-            $this->setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, post-check=0, pre-check=0', false);
+            $this->setHeader('Cache-Control', 'no-cache, must-revalidate, post-check=0, pre-check=0', false);
 
             // HTTP 1.0
             $this->setHeader('Pragma', 'no-cache');

--- a/src/AbstractWebApplication.php
+++ b/src/AbstractWebApplication.php
@@ -378,9 +378,6 @@ abstract class AbstractWebApplication extends AbstractApplication implements Web
             // Always modified.
             $this->setHeader('Last-Modified', \gmdate('D, d M Y H:i:s') . ' GMT', true);
             $this->setHeader('Cache-Control', 'no-cache, must-revalidate', false);
-
-            // HTTP 1.0
-            $this->setHeader('Pragma', 'no-cache');
         } else {
             // Expires.
             if (!$this->getResponse()->hasHeader('Expires')) {


### PR DESCRIPTION
### Summary of Changes

Removed:
 `no-store`  fix for https://github.com/joomla/joomla-cms/issues/45403
 `post-check`, `pre-check` unused  stuff from IE era
 `Pragma` replaced with `Cache-Control`  (see [Pragma header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Pragma))

### Testing Instructions

Code review.

