### PR TITLE
Update unittests to phpunit 12

### DIFF
--- a/Tests/AbstractApplicationTest.php
+++ b/Tests/AbstractApplicationTest.php
@@ -8,6 +8,7 @@
 namespace Joomla\Application\Tests;
 
 use Joomla\Application\AbstractApplication;
+use Joomla\Application\Tests\Stubs\ConcreteApplication;
 use Joomla\Event\DispatcherInterface;
 use Joomla\Registry\Registry;
 use Joomla\Test\TestHelper;
@@ -32,7 +33,7 @@ class AbstractApplicationTest extends TestCase
         $startTime      = \time();
         $startMicrotime = \microtime(true);
 
-        $object = $this->getMockForAbstractClass(AbstractApplication::class);
+        $object = new ConcreteApplication();
 
         $this->assertInstanceOf(
             Registry::class,
@@ -56,7 +57,7 @@ class AbstractApplicationTest extends TestCase
     public function testConstructDependencyInjection()
     {
         $mockConfig = $this->createMock(Registry::class);
-        $object     = $this->getMockForAbstractClass(AbstractApplication::class, [$mockConfig]);
+        $object     = new ConcreteApplication($mockConfig);
 
         $this->assertSame(
             $mockConfig,
@@ -72,10 +73,10 @@ class AbstractApplicationTest extends TestCase
      */
     public function testClose()
     {
-        $object = $this->getMockBuilder(AbstractApplication::class)
+        $object = $this->getMockBuilder(ConcreteApplication::class)
             ->onlyMethods(['close'])
             ->disableOriginalConstructor()
-            ->getMockForAbstractClass();
+            ->getMock();
 
         $object->expects($this->any())
             ->method('close')
@@ -91,11 +92,11 @@ class AbstractApplicationTest extends TestCase
      */
     public function testExecute()
     {
-        $object = $this->getMockForAbstractClass(AbstractApplication::class);
-        $object->expects($this->once())
-            ->method('doExecute');
+        $object = new ConcreteApplication();
 
         $object->execute();
+
+        $this->assertTrue($object->executed, 'doExecute() is called by execute()');
     }
 
     /**
@@ -110,13 +111,12 @@ class AbstractApplicationTest extends TestCase
         $dispatcher->expects($this->exactly(2))
             ->method('dispatch');
 
-        $object = $this->getMockForAbstractClass(AbstractApplication::class);
-        $object->expects($this->once())
-            ->method('doExecute');
-
+        $object = new ConcreteApplication();
         $object->setDispatcher($dispatcher);
 
         $object->execute();
+
+        $this->assertTrue($object->executed, 'doExecute() is called by execute()');
     }
 
     /**
@@ -126,12 +126,9 @@ class AbstractApplicationTest extends TestCase
      */
     public function testGet()
     {
-        $mockConfig = $this->getMockBuilder(Registry::class)
-            ->setConstructorArgs([['foo' => 'bar']])
-            ->enableProxyingToOriginalMethods()
-            ->getMock();
+        $mockConfig = new Registry(['foo' => 'bar']);
 
-        $object = $this->getMockForAbstractClass(AbstractApplication::class, [$mockConfig]);
+        $object = new ConcreteApplication($mockConfig);
 
         $this->assertSame('bar', $object->get('foo', 'car'), 'Checks a known configuration setting is returned.');
         $this->assertSame('car', $object->get('goo', 'car'), 'Checks an unknown configuration setting returns the default.');
@@ -144,7 +141,7 @@ class AbstractApplicationTest extends TestCase
      */
     public function testGetLogger()
     {
-        $object = $this->getMockForAbstractClass(AbstractApplication::class);
+        $object = new ConcreteApplication();
 
         $this->assertInstanceOf(NullLogger::class, $object->getLogger());
     }
@@ -156,11 +153,9 @@ class AbstractApplicationTest extends TestCase
      */
     public function testSet()
     {
-        $mockConfig = $this->getMockBuilder(Registry::class)
-            ->enableProxyingToOriginalMethods()
-            ->getMock();
+        $mockConfig = new Registry();
 
-        $object = $this->getMockForAbstractClass(AbstractApplication::class, [$mockConfig]);
+        $object = new ConcreteApplication($mockConfig);
 
         $this->assertNull($object->set('foo', 'car'), 'Checks set returns the previous value.');
         $this->assertEquals('car', $object->get('foo'), 'Checks the new value has been set.');
@@ -173,7 +168,7 @@ class AbstractApplicationTest extends TestCase
      */
     public function testSetConfiguration()
     {
-        $object     = $this->getMockForAbstractClass(AbstractApplication::class);
+        $object     = new ConcreteApplication();
         $mockConfig = $this->createMock(Registry::class);
 
         $this->assertSame($object, $object->setConfiguration($mockConfig), 'The setConfiguration method has a fluent interface');
@@ -192,7 +187,7 @@ class AbstractApplicationTest extends TestCase
      */
     public function testSetLogger()
     {
-        $object     = $this->getMockForAbstractClass(AbstractApplication::class);
+        $object     = new ConcreteApplication();
         $mockLogger = $this->createMock(LoggerInterface::class);
 
         $object->setLogger($mockLogger);

--- a/Tests/AbstractWebApplicationTest.php
+++ b/Tests/AbstractWebApplicationTest.php
@@ -8,12 +8,15 @@
 namespace Joomla\Application\Tests;
 
 use Joomla\Application\AbstractWebApplication;
+use Joomla\Application\Tests\Stubs\ConcreteWebApplication;
 use Joomla\Application\Web\WebClient;
 use Joomla\Event\DispatcherInterface;
 use Joomla\Input\Input;
 use Joomla\Registry\Registry;
 use Joomla\Test\TestHelper;
 use Laminas\Diactoros\Response\TextResponse;
+use PHPUnit\Framework\Attributes\BackupGlobals;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -146,7 +149,7 @@ class AbstractWebApplicationTest extends TestCase
      */
     public function testConstructDefaultBehaviour()
     {
-        $object = $this->getMockForAbstractClass(AbstractWebApplication::class);
+        $object = new ConcreteWebApplication();
 
         // Validate default objects unique to the web application are created
         $this->assertInstanceOf(WebClient::class, $object->client);
@@ -157,9 +160,8 @@ class AbstractWebApplicationTest extends TestCase
      *
      * @covers        \Joomla\Application\AbstractWebApplication
      * @uses          \Joomla\Application\AbstractApplication
-     *
-     * @backupGlobals enabled
      */
+    #[BackupGlobals(true)]
     public function testConstructDependencyInjection()
     {
         $_SERVER['HTTP_HOST']   = self::TEST_HTTP_HOST;
@@ -168,13 +170,11 @@ class AbstractWebApplicationTest extends TestCase
 
         $mockInput = new Input([]);
 
-        $mockConfig = $this->getMockBuilder(Registry::class)
-            ->enableProxyingToOriginalMethods()
-            ->getMock();
+        $mockConfig = new Registry();
 
         $mockClient = $this->createMock(WebClient::class);
 
-        $object = $this->getMockForAbstractClass(AbstractWebApplication::class, [$mockInput, $mockConfig, $mockClient]);
+        $object = new ConcreteWebApplication($mockInput, $mockConfig, $mockClient);
 
         $this->assertSame($mockInput, $object->getInput());
 
@@ -198,7 +198,7 @@ class AbstractWebApplicationTest extends TestCase
      */
     public function testGetDeprecatedInputReadAccess()
     {
-        $object = $this->getMockForAbstractClass(AbstractWebApplication::class);
+        $object = new ConcreteWebApplication();
 
         // Validate default objects unique to the web application are created
         $this->assertInstanceOf(Input::class, $object->getInput());
@@ -213,7 +213,11 @@ class AbstractWebApplicationTest extends TestCase
      */
     public function testExecute()
     {
-        $object = $this->getMockForAbstractClass(AbstractWebApplication::class);
+        $object = $this->getMockBuilder(ConcreteWebApplication::class)
+            ->setConstructorArgs([])
+            ->onlyMethods(['doExecute'])
+            ->getMock();
+
         $object->expects($this->once())
             ->method('doExecute');
 
@@ -248,7 +252,11 @@ class AbstractWebApplicationTest extends TestCase
         $dispatcher->expects($this->exactly(4))
             ->method('dispatch');
 
-        $object = $this->getMockForAbstractClass(AbstractWebApplication::class);
+        $object = $this->getMockBuilder(ConcreteWebApplication::class)
+            ->setConstructorArgs([])
+            ->onlyMethods(['doExecute'])
+            ->getMock();
+
         $object->expects($this->once())
             ->method('doExecute');
 
@@ -285,12 +293,13 @@ class AbstractWebApplicationTest extends TestCase
             $this->markTestSkipped('Output compression is unsupported in this environment.');
         }
 
-        $mockConfig = $this->getMockBuilder(Registry::class)
-            ->setConstructorArgs([['gzip' => true]])
-            ->enableProxyingToOriginalMethods()
+        $mockConfig = new Registry(['gzip' => true]);
+
+        $object = $this->getMockBuilder(ConcreteWebApplication::class)
+            ->setConstructorArgs([null, $mockConfig])
+            ->onlyMethods(['doExecute'])
             ->getMock();
 
-        $object = $this->getMockForAbstractClass(AbstractWebApplication::class, [null, $mockConfig]);
         $object->expects($this->once())
             ->method('doExecute');
 
@@ -320,10 +329,7 @@ class AbstractWebApplicationTest extends TestCase
      */
     public function testCompressWithGzipEncoding()
     {
-        $mockClient = $this->getMockBuilder(WebClient::class)
-            ->setConstructorArgs([null, 'gzip, deflate'])
-            ->enableProxyingToOriginalMethods()
-            ->getMock();
+        $mockClient = new WebClient(null, 'gzip, deflate');
 
         // Mock the client internals to show encoding has been detected.
         TestHelper::setValue(
@@ -337,10 +343,10 @@ class AbstractWebApplicationTest extends TestCase
             ['gzip', 'deflate']
         );
 
-        $object = $this->getMockBuilder(AbstractWebApplication::class)
+        $object = $this->getMockBuilder(ConcreteWebApplication::class)
             ->setConstructorArgs([null, null, $mockClient])
             ->onlyMethods(['checkHeadersSent'])
-            ->getMockForAbstractClass();
+            ->getMock();
 
         $object->expects($this->once())
             ->method('checkHeadersSent')
@@ -390,10 +396,7 @@ class AbstractWebApplicationTest extends TestCase
      */
     public function testCompressWithDeflateEncoding()
     {
-        $mockClient = $this->getMockBuilder(WebClient::class)
-            ->setConstructorArgs([null, 'deflate'])
-            ->enableProxyingToOriginalMethods()
-            ->getMock();
+        $mockClient = new WebClient(null, 'deflate');
 
         // Mock the client internals to show encoding has been detected.
         TestHelper::setValue(
@@ -407,10 +410,10 @@ class AbstractWebApplicationTest extends TestCase
             ['deflate', 'gzip']
         );
 
-        $object = $this->getMockBuilder(AbstractWebApplication::class)
+        $object = $this->getMockBuilder(ConcreteWebApplication::class)
             ->setConstructorArgs([null, null, $mockClient])
             ->onlyMethods(['checkHeadersSent'])
-            ->getMockForAbstractClass();
+            ->getMock();
 
         $object->expects($this->once())
             ->method('checkHeadersSent')
@@ -460,9 +463,7 @@ class AbstractWebApplicationTest extends TestCase
      */
     public function testCompressWithNoAcceptEncodings()
     {
-        $mockClient = $this->getMockBuilder(WebClient::class)
-            ->enableProxyingToOriginalMethods()
-            ->getMock();
+        $mockClient = new WebClient();
 
         // Mock the client internals to show encoding has been detected.
         TestHelper::setValue(
@@ -471,10 +472,10 @@ class AbstractWebApplicationTest extends TestCase
             ['acceptEncoding' => true]
         );
 
-        $object = $this->getMockBuilder(AbstractWebApplication::class)
+        $object = $this->getMockBuilder(ConcreteWebApplication::class)
             ->setConstructorArgs([null, null, $mockClient])
             ->onlyMethods(['checkHeadersSent'])
-            ->getMockForAbstractClass();
+            ->getMock();
 
         // Mock a response.
         $response = new TextResponse(
@@ -514,10 +515,7 @@ class AbstractWebApplicationTest extends TestCase
      */
     public function testCompressWithHeadersSent()
     {
-        $mockClient = $this->getMockBuilder(WebClient::class)
-            ->setConstructorArgs([null, 'deflate'])
-            ->enableProxyingToOriginalMethods()
-            ->getMock();
+        $mockClient = new WebClient(null, 'deflate');
 
         // Mock the client internals to show encoding has been detected.
         TestHelper::setValue(
@@ -531,10 +529,10 @@ class AbstractWebApplicationTest extends TestCase
             ['deflate', 'gzip']
         );
 
-        $object = $this->getMockBuilder(AbstractWebApplication::class)
+        $object = $this->getMockBuilder(ConcreteWebApplication::class)
             ->setConstructorArgs([null, null, $mockClient])
             ->onlyMethods(['checkHeadersSent'])
-            ->getMockForAbstractClass();
+            ->getMock();
 
         $object->expects($this->once())
             ->method('checkHeadersSent')
@@ -579,9 +577,7 @@ class AbstractWebApplicationTest extends TestCase
      */
     public function testCompressWithUnsupportedEncodings()
     {
-        $mockClient = $this->getMockBuilder(WebClient::class)
-            ->enableProxyingToOriginalMethods()
-            ->getMock();
+        $mockClient = new WebClient();
 
         // Mock the client internals to show encoding has been detected.
         TestHelper::setValue(
@@ -595,7 +591,7 @@ class AbstractWebApplicationTest extends TestCase
             ['foo', 'bar']
         );
 
-        $object = $this->getMockForAbstractClass(AbstractWebApplication::class, [null, null, $mockClient]);
+        $object = new ConcreteWebApplication(null, null, $mockClient);
 
         // Mock a response.
         $response = new TextResponse(
@@ -635,7 +631,7 @@ class AbstractWebApplicationTest extends TestCase
      */
     public function testRespond()
     {
-        $object = $this->getMockForAbstractClass(AbstractWebApplication::class);
+        $object = new ConcreteWebApplication();
 
         TestHelper::invoke($object, 'respond');
 
@@ -665,7 +661,7 @@ class AbstractWebApplicationTest extends TestCase
     {
         $modifiedDate = new \DateTime('now', new \DateTimeZone('GMT'));
 
-        $object = $this->getMockForAbstractClass(AbstractWebApplication::class);
+        $object = new ConcreteWebApplication();
         $object->allowCache(true);
         $object->modifiedDate = $modifiedDate;
 
@@ -692,9 +688,8 @@ class AbstractWebApplicationTest extends TestCase
      * @covers        \Joomla\Application\AbstractWebApplication
      * @uses          \Joomla\Application\AbstractApplication
      * @uses          \Joomla\Application\Web\WebClient
-     *
-     * @backupGlobals enabled
      */
+    #[BackupGlobals(true)]
     public function testRedirectLegacyBehavior()
     {
         $_SERVER['HTTP_HOST']   = self::TEST_HTTP_HOST;
@@ -703,9 +698,7 @@ class AbstractWebApplicationTest extends TestCase
 
         $mockInput = new Input([]);
 
-        $mockConfig = $this->getMockBuilder(Registry::class)
-            ->enableProxyingToOriginalMethods()
-            ->getMock();
+        $mockConfig = new Registry();
 
         $mockClient = $this->createMock(WebClient::class);
 
@@ -721,15 +714,10 @@ class AbstractWebApplicationTest extends TestCase
             WebClient::GECKO
         );
 
-        $object = $this->getMockForAbstractClass(
-            AbstractWebApplication::class,
-            [$mockInput, $mockConfig, $mockClient],
-            '',
-            true,
-            true,
-            true,
-            ['checkHeadersSent', 'close', 'header']
-        );
+        $object = $this->getMockBuilder(ConcreteWebApplication::class)
+            ->setConstructorArgs([$mockInput, $mockConfig, $mockClient])
+            ->onlyMethods(['checkHeadersSent', 'close', 'header'])
+            ->getMock();
 
         $object->expects($this->once())
             ->method('close');
@@ -767,9 +755,8 @@ class AbstractWebApplicationTest extends TestCase
      * @covers        \Joomla\Application\AbstractWebApplication
      * @uses          \Joomla\Application\AbstractApplication
      * @uses          \Joomla\Application\Web\WebClient
-     *
-     * @backupGlobals enabled
      */
+    #[BackupGlobals(true)]
     public function testRedirect()
     {
         $_SERVER['HTTP_HOST']   = self::TEST_HTTP_HOST;
@@ -778,9 +765,7 @@ class AbstractWebApplicationTest extends TestCase
 
         $mockInput = new Input([]);
 
-        $mockConfig = $this->getMockBuilder(Registry::class)
-            ->enableProxyingToOriginalMethods()
-            ->getMock();
+        $mockConfig = new Registry();
 
         $mockClient = $this->getMockBuilder(WebClient::class)->getMock();
 
@@ -796,15 +781,10 @@ class AbstractWebApplicationTest extends TestCase
             WebClient::GECKO
         );
 
-        $object = $this->getMockForAbstractClass(
-            AbstractWebApplication::class,
-            [$mockInput, $mockConfig, $mockClient],
-            '',
-            true,
-            true,
-            true,
-            ['checkHeadersSent', 'close', 'header']
-        );
+        $object = $this->getMockBuilder(ConcreteWebApplication::class)
+            ->setConstructorArgs([$mockInput, $mockConfig, $mockClient])
+            ->onlyMethods(['checkHeadersSent', 'close', 'header'])
+            ->getMock();
 
         $object->expects($this->once())
             ->method('close');
@@ -841,9 +821,8 @@ class AbstractWebApplicationTest extends TestCase
      * @covers        \Joomla\Application\AbstractWebApplication
      * @uses          \Joomla\Application\AbstractApplication
      * @uses          \Joomla\Application\Web\WebClient
-     *
-     * @backupGlobals enabled
      */
+    #[BackupGlobals(true)]
     public function testRedirectWithExistingStatusCode()
     {
         $_SERVER['HTTP_HOST']   = self::TEST_HTTP_HOST;
@@ -852,9 +831,7 @@ class AbstractWebApplicationTest extends TestCase
 
         $mockInput = new Input([]);
 
-        $mockConfig = $this->getMockBuilder(Registry::class)
-            ->enableProxyingToOriginalMethods()
-            ->getMock();
+        $mockConfig = new Registry();
 
         $mockClient = $this->getMockBuilder(WebClient::class)->getMock();
 
@@ -870,15 +847,10 @@ class AbstractWebApplicationTest extends TestCase
             WebClient::GECKO
         );
 
-        $object = $this->getMockForAbstractClass(
-            AbstractWebApplication::class,
-            [$mockInput, $mockConfig, $mockClient],
-            '',
-            true,
-            true,
-            true,
-            ['checkHeadersSent', 'close', 'header']
-        );
+        $object = $this->getMockBuilder(ConcreteWebApplication::class)
+            ->setConstructorArgs([$mockInput, $mockConfig, $mockClient])
+            ->onlyMethods(['checkHeadersSent', 'close', 'header'])
+            ->getMock();
 
         $object->expects($this->once())
             ->method('close');
@@ -917,9 +889,8 @@ class AbstractWebApplicationTest extends TestCase
      * @covers        \Joomla\Application\AbstractWebApplication
      * @uses          \Joomla\Application\AbstractApplication
      * @uses          \Joomla\Application\Web\WebClient
-     *
-     * @backupGlobals enabled
      */
+    #[BackupGlobals(true)]
     public function testRedirectWithAdditionalHeaders()
     {
         $_SERVER['HTTP_HOST']   = self::TEST_HTTP_HOST;
@@ -928,9 +899,7 @@ class AbstractWebApplicationTest extends TestCase
 
         $mockInput = new Input([]);
 
-        $mockConfig = $this->getMockBuilder(Registry::class)
-            ->enableProxyingToOriginalMethods()
-            ->getMock();
+        $mockConfig = new Registry();
 
         $mockClient = $this->getMockBuilder(WebClient::class)->getMock();
 
@@ -946,15 +915,10 @@ class AbstractWebApplicationTest extends TestCase
             WebClient::GECKO
         );
 
-        $object = $this->getMockForAbstractClass(
-            AbstractWebApplication::class,
-            [$mockInput, $mockConfig, $mockClient],
-            '',
-            true,
-            true,
-            true,
-            ['checkHeadersSent', 'close', 'header']
-        );
+        $object = $this->getMockBuilder(ConcreteWebApplication::class)
+            ->setConstructorArgs([$mockInput, $mockConfig, $mockClient])
+            ->onlyMethods(['checkHeadersSent', 'close', 'header'])
+            ->getMock();
 
         $object->expects($this->once())
             ->method('close');
@@ -995,8 +959,8 @@ class AbstractWebApplicationTest extends TestCase
      *
      * @runInSeparateProcess
      * @preserveGlobalState disabled
-     * @backupGlobals       enabled
      */
+    #[BackupGlobals(true)]
     public function testRedirectWithHeadersSent()
     {
         $_SERVER['HTTP_HOST']   = self::TEST_HTTP_HOST;
@@ -1005,19 +969,12 @@ class AbstractWebApplicationTest extends TestCase
 
         $mockInput = new Input([]);
 
-        $mockConfig = $this->getMockBuilder(Registry::class)
-            ->enableProxyingToOriginalMethods()
-            ->getMock();
+        $mockConfig = new Registry();
 
-        $object = $this->getMockForAbstractClass(
-            AbstractWebApplication::class,
-            [$mockInput, $mockConfig],
-            '',
-            true,
-            true,
-            true,
-            ['checkHeadersSent', 'close']
-        );
+        $object = $this->getMockBuilder(ConcreteWebApplication::class)
+            ->setConstructorArgs([$mockInput, $mockConfig])
+            ->onlyMethods(['checkHeadersSent', 'close'])
+            ->getMock();
 
         $object->expects($this->once())
             ->method('close')
@@ -1047,9 +1004,8 @@ class AbstractWebApplicationTest extends TestCase
      * @covers        \Joomla\Application\AbstractWebApplication
      * @uses          \Joomla\Application\AbstractApplication
      * @uses          \Joomla\Application\Web\WebClient
-     *
-     * @backupGlobals enabled
      */
+    #[BackupGlobals(true)]
     public function testRedirectWithJavascriptRedirect()
     {
         $_SERVER['HTTP_HOST']   = self::TEST_HTTP_HOST;
@@ -1058,14 +1014,9 @@ class AbstractWebApplicationTest extends TestCase
 
         $mockInput = new Input([]);
 
-        $mockConfig = $this->getMockBuilder(Registry::class)
-            ->enableProxyingToOriginalMethods()
-            ->getMock();
+        $mockConfig = new Registry();
 
-        $mockClient = $this->getMockBuilder(WebClient::class)
-            ->setConstructorArgs(['MSIE'])
-            ->enableProxyingToOriginalMethods()
-            ->getMock();
+        $mockClient = new WebClient('MSIE');
 
         // Mock the client internals to show engine has been detected.
         TestHelper::setValue(
@@ -1079,15 +1030,10 @@ class AbstractWebApplicationTest extends TestCase
             WebClient::TRIDENT
         );
 
-        $object = $this->getMockForAbstractClass(
-            AbstractWebApplication::class,
-            [$mockInput, $mockConfig, $mockClient],
-            '',
-            true,
-            true,
-            true,
-            ['checkHeadersSent', 'close', 'header']
-        );
+        $object = $this->getMockBuilder(ConcreteWebApplication::class)
+            ->setConstructorArgs([$mockInput, $mockConfig, $mockClient])
+            ->onlyMethods(['checkHeadersSent', 'close', 'header'])
+            ->getMock();
 
         $object->expects($this->once())
             ->method('close');
@@ -1115,9 +1061,8 @@ class AbstractWebApplicationTest extends TestCase
      * @covers        \Joomla\Application\AbstractWebApplication
      * @uses          \Joomla\Application\AbstractApplication
      * @uses          \Joomla\Application\Web\WebClient
-     *
-     * @backupGlobals enabled
      */
+    #[BackupGlobals(true)]
     public function testRedirectWithMoved()
     {
         $_SERVER['HTTP_HOST']   = self::TEST_HTTP_HOST;
@@ -1126,9 +1071,7 @@ class AbstractWebApplicationTest extends TestCase
 
         $mockInput = new Input([]);
 
-        $mockConfig = $this->getMockBuilder(Registry::class)
-            ->enableProxyingToOriginalMethods()
-            ->getMock();
+        $mockConfig = new Registry();
 
         $mockClient = $this->getMockBuilder(WebClient::class)->getMock();
 
@@ -1144,15 +1087,10 @@ class AbstractWebApplicationTest extends TestCase
             WebClient::GECKO
         );
 
-        $object = $this->getMockForAbstractClass(
-            AbstractWebApplication::class,
-            [$mockInput, $mockConfig, $mockClient],
-            '',
-            true,
-            true,
-            true,
-            ['checkHeadersSent', 'close', 'header']
-        );
+        $object = $this->getMockBuilder(ConcreteWebApplication::class)
+            ->setConstructorArgs([$mockInput, $mockConfig, $mockClient])
+            ->onlyMethods(['checkHeadersSent', 'close', 'header'])
+            ->getMock();
 
         $object->expects($this->once())
             ->method('close');
@@ -1193,10 +1131,9 @@ class AbstractWebApplicationTest extends TestCase
      * @covers        \Joomla\Application\AbstractWebApplication
      * @uses          \Joomla\Application\AbstractApplication
      * @uses          \Joomla\Application\Web\WebClient
-     *
-     * @dataProvider  getRedirectData
-     * @backupGlobals enabled
      */
+    #[DataProvider('getRedirectData')]
+    #[BackupGlobals(true)]
     public function testRedirectWithUrl(string $url, string $expected)
     {
         $_SERVER['HTTP_HOST']   = self::TEST_HTTP_HOST;
@@ -1205,9 +1142,7 @@ class AbstractWebApplicationTest extends TestCase
 
         $mockInput = new Input([]);
 
-        $mockConfig = $this->getMockBuilder(Registry::class)
-            ->enableProxyingToOriginalMethods()
-            ->getMock();
+        $mockConfig = new Registry();
 
         $mockClient = $this->getMockBuilder(WebClient::class)->getMock();
 
@@ -1223,15 +1158,10 @@ class AbstractWebApplicationTest extends TestCase
             WebClient::GECKO
         );
 
-        $object = $this->getMockForAbstractClass(
-            AbstractWebApplication::class,
-            [$mockInput, $mockConfig, $mockClient],
-            '',
-            true,
-            true,
-            true,
-            ['checkHeadersSent', 'close', 'header']
-        );
+        $object = $this->getMockBuilder(ConcreteWebApplication::class)
+            ->setConstructorArgs([$mockInput, $mockConfig, $mockClient])
+            ->onlyMethods(['checkHeadersSent', 'close', 'header'])
+            ->getMock();
 
         $object->expects($this->once())
             ->method('close');
@@ -1259,7 +1189,7 @@ class AbstractWebApplicationTest extends TestCase
      */
     public function testAllowCache()
     {
-        $object = $this->getMockForAbstractClass(AbstractWebApplication::class);
+        $object = new ConcreteWebApplication();
 
         $this->assertFalse($object->allowCache());
         $this->assertTrue($object->allowCache(true));
@@ -1274,7 +1204,7 @@ class AbstractWebApplicationTest extends TestCase
      */
     public function testSetHeader()
     {
-        $object = $this->getMockForAbstractClass(AbstractWebApplication::class);
+        $object = new ConcreteWebApplication();
 
         $object->setHeader('foo', 'bar');
 
@@ -1305,7 +1235,7 @@ class AbstractWebApplicationTest extends TestCase
      */
     public function testClearHeaders()
     {
-        $object = $this->getMockForAbstractClass(AbstractWebApplication::class);
+        $object = new ConcreteWebApplication();
         $object->setHeader('foo', 'bar');
         $oldHeaders = $object->getHeaders();
 
@@ -1322,15 +1252,10 @@ class AbstractWebApplicationTest extends TestCase
      */
     public function testSendHeaders()
     {
-        $object = $this->getMockForAbstractClass(
-            AbstractWebApplication::class,
-            [],
-            '',
-            true,
-            true,
-            true,
-            ['checkHeadersSent', 'header']
-        );
+        $object = $this->getMockBuilder(ConcreteWebApplication::class)
+            ->setConstructorArgs([])
+            ->onlyMethods(['checkHeadersSent', 'header'])
+            ->getMock();
 
         $object->expects($this->any())
             ->method('checkHeadersSent')
@@ -1361,7 +1286,7 @@ class AbstractWebApplicationTest extends TestCase
      */
     public function testSetBody()
     {
-        $object = $this->getMockForAbstractClass(AbstractWebApplication::class);
+        $object = new ConcreteWebApplication();
 
         $this->assertSame($object, $object->setBody('Testing'));
         $this->assertSame('Testing', $object->getBody());
@@ -1376,7 +1301,7 @@ class AbstractWebApplicationTest extends TestCase
      */
     public function testPrependBody()
     {
-        $object = $this->getMockForAbstractClass(AbstractWebApplication::class);
+        $object = new ConcreteWebApplication();
 
         $object->setBody('Testing');
         $this->assertSame($object, $object->prependBody('Pre-'));
@@ -1392,7 +1317,7 @@ class AbstractWebApplicationTest extends TestCase
      */
     public function testAppendBody()
     {
-        $object = $this->getMockForAbstractClass(AbstractWebApplication::class);
+        $object = new ConcreteWebApplication();
 
         $object->setBody('Testing');
         $this->assertSame($object, $object->appendBody(' Later'));
@@ -1408,7 +1333,7 @@ class AbstractWebApplicationTest extends TestCase
      */
     public function testGetBody()
     {
-        $object = $this->getMockForAbstractClass(AbstractWebApplication::class);
+        $object = new ConcreteWebApplication();
 
         $this->assertSame('', $object->getBody(), 'Returns an empty string by default');
     }
@@ -1427,10 +1352,9 @@ class AbstractWebApplicationTest extends TestCase
      * @covers        \Joomla\Application\AbstractWebApplication
      * @uses          \Joomla\Application\AbstractApplication
      * @uses          \Joomla\Application\Web\WebClient
-     *
-     * @dataProvider  getDetectRequestUriData
-     * @backupGlobals enabled
      */
+    #[DataProvider('getDetectRequestUriData')]
+    #[BackupGlobals(true)]
     public function testDetectRequestUri(
         ?string $https,
         string $phpSelf,
@@ -1452,7 +1376,7 @@ class AbstractWebApplicationTest extends TestCase
             $_SERVER['HTTPS'] = $https;
         }
 
-        $object = $this->getMockForAbstractClass(AbstractWebApplication::class, [$mockInput]);
+        $object = new ConcreteWebApplication($mockInput);
 
         $this->assertSame(
             $expects,
@@ -1469,12 +1393,9 @@ class AbstractWebApplicationTest extends TestCase
      */
     public function testLoadSystemUrisWithSiteUriSet()
     {
-        $mockConfig = $this->getMockBuilder(Registry::class)
-            ->setConstructorArgs([['site_uri' => 'http://test.joomla.org/path/']])
-            ->enableProxyingToOriginalMethods()
-            ->getMock();
+        $mockConfig = new Registry(['site_uri' => 'http://test.joomla.org/path/']);
 
-        $object = $this->getMockForAbstractClass(AbstractWebApplication::class, [null, $mockConfig]);
+        $object = new ConcreteWebApplication(null, $mockConfig);
 
         TestHelper::invoke($object, 'loadSystemUris');
 
@@ -1510,9 +1431,8 @@ class AbstractWebApplicationTest extends TestCase
      * @covers        \Joomla\Application\AbstractWebApplication
      * @uses          \Joomla\Application\AbstractApplication
      * @uses          \Joomla\Application\Web\WebClient
-     *
-     * @backupGlobals enabled
      */
+    #[BackupGlobals(true)]
     public function testLoadSystemUrisWithoutSiteUriSet()
     {
         $_SERVER['HTTP_HOST']   = self::TEST_HTTP_HOST;
@@ -1520,7 +1440,7 @@ class AbstractWebApplicationTest extends TestCase
 
         $mockInput = new Input([]);
 
-        $object = $this->getMockForAbstractClass(AbstractWebApplication::class, [$mockInput]);
+        $object = new ConcreteWebApplication($mockInput);
 
         TestHelper::invoke($object, 'loadSystemUris', 'http://joom.la/application');
 
@@ -1557,9 +1477,8 @@ class AbstractWebApplicationTest extends TestCase
      * @covers        \Joomla\Application\AbstractWebApplication
      * @uses          \Joomla\Application\AbstractApplication
      * @uses          \Joomla\Application\Web\WebClient
-     *
-     * @backupGlobals enabled
      */
+    #[BackupGlobals(true)]
     public function testLoadSystemUrisWithoutSiteUriWithMediaUriSet()
     {
         $_SERVER['HTTP_HOST']   = self::TEST_HTTP_HOST;
@@ -1567,12 +1486,9 @@ class AbstractWebApplicationTest extends TestCase
 
         $mockInput = new Input([]);
 
-        $mockConfig = $this->getMockBuilder(Registry::class)
-            ->setConstructorArgs([['media_uri' => 'http://cdn.joomla.org/media/']])
-            ->enableProxyingToOriginalMethods()
-            ->getMock();
+        $mockConfig = new Registry(['media_uri' => 'http://cdn.joomla.org/media/']);
 
-        $object = $this->getMockForAbstractClass(AbstractWebApplication::class, [$mockInput, $mockConfig]);
+        $object = new ConcreteWebApplication($mockInput, $mockConfig);
 
         TestHelper::invoke($object, 'loadSystemUris', 'http://joom.la/application');
 
@@ -1609,9 +1525,8 @@ class AbstractWebApplicationTest extends TestCase
      * @covers        \Joomla\Application\AbstractWebApplication
      * @uses          \Joomla\Application\AbstractApplication
      * @uses          \Joomla\Application\Web\WebClient
-     *
-     * @backupGlobals enabled
      */
+    #[BackupGlobals(true)]
     public function testLoadSystemUrisWithoutSiteUriWithRelativeMediaUriSet()
     {
         $_SERVER['HTTP_HOST']   = self::TEST_HTTP_HOST;
@@ -1619,12 +1534,9 @@ class AbstractWebApplicationTest extends TestCase
 
         $mockInput = new Input([]);
 
-        $mockConfig = $this->getMockBuilder(Registry::class)
-            ->setConstructorArgs([['media_uri' => '/media/']])
-            ->enableProxyingToOriginalMethods()
-            ->getMock();
+        $mockConfig = new Registry(['media_uri' => '/media/']);
 
-        $object = $this->getMockForAbstractClass(AbstractWebApplication::class, [$mockInput, $mockConfig]);
+        $object = new ConcreteWebApplication($mockInput, $mockConfig);
 
         TestHelper::invoke($object, 'loadSystemUris', 'http://joom.la/application');
 
@@ -1660,12 +1572,11 @@ class AbstractWebApplicationTest extends TestCase
      * @covers        \Joomla\Application\AbstractWebApplication
      * @uses          \Joomla\Application\AbstractApplication
      * @uses          \Joomla\Application\Web\WebClient
-     *
-     * @backupGlobals enabled
      */
+    #[BackupGlobals(true)]
     public function testisSslConnection()
     {
-        $object = $this->getMockForAbstractClass(AbstractWebApplication::class);
+        $object = new ConcreteWebApplication();
 
         $this->assertFalse($object->isSslConnection());
 
@@ -1683,7 +1594,7 @@ class AbstractWebApplicationTest extends TestCase
      */
     public function testGetHttpStatusValue()
     {
-        $object = $this->getMockForAbstractClass(AbstractWebApplication::class);
+        $object = new ConcreteWebApplication();
 
         $this->assertTrue($object->isValidHttpStatus(500));
     }
@@ -1697,7 +1608,7 @@ class AbstractWebApplicationTest extends TestCase
      */
     public function testInvalidHttpStatusValue()
     {
-        $object = $this->getMockForAbstractClass(AbstractWebApplication::class);
+        $object = new ConcreteWebApplication();
 
         $this->assertFalse($object->isValidHttpStatus(460));
     }

--- a/Tests/Stubs/ConcreteApplication.php
+++ b/Tests/Stubs/ConcreteApplication.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * @copyright  (C) 2013 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Application\Tests\Stubs;
+
+use Joomla\Application\AbstractApplication;
+
+/**
+ * Concrete implementation of AbstractApplication for testing.
+ *
+ * PHPUnit 12 removed getMockForAbstractClass(), so tests that need an instance of the abstract
+ * application use this stub, and tests that need to observe doExecute() build a mock of it.
+ */
+class ConcreteApplication extends AbstractApplication
+{
+    /**
+     * Records whether doExecute() was called.
+     *
+     * @var  boolean
+     */
+    public $executed = false;
+
+    /**
+     * Method to run the application routines.
+     *
+     * @return  void
+     */
+    protected function doExecute()
+    {
+        $this->executed = true;
+    }
+}

--- a/Tests/Stubs/ConcreteWebApplication.php
+++ b/Tests/Stubs/ConcreteWebApplication.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * @copyright  (C) 2013 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Application\Tests\Stubs;
+
+use Joomla\Application\AbstractWebApplication;
+
+/**
+ * Concrete implementation of AbstractWebApplication for testing.
+ *
+ * PHPUnit 12 removed getMockForAbstractClass(), so tests that need an instance of the abstract
+ * web application use this stub, and tests that need to observe or replace doExecute() build a
+ * mock of it.
+ */
+class ConcreteWebApplication extends AbstractWebApplication
+{
+    /**
+     * Records whether doExecute() was called.
+     *
+     * @var  boolean
+     */
+    public $executed = false;
+
+    /**
+     * Method to run the application routines.
+     *
+     * @return  void
+     */
+    protected function doExecute()
+    {
+        $this->executed = true;
+    }
+}

--- a/Tests/Stubs/SessionAwareApplication.php
+++ b/Tests/Stubs/SessionAwareApplication.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * @copyright  (C) 2019 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Application\Tests\Stubs;
+
+use Joomla\Application\SessionAwareWebApplicationTrait;
+use Joomla\Input\Input;
+
+/**
+ * Concrete host for SessionAwareWebApplicationTrait.
+ *
+ * PHPUnit 12 removed getMockForTrait(), so the trait is exercised through this class instead.
+ */
+class SessionAwareApplication
+{
+    use SessionAwareWebApplicationTrait;
+
+    /**
+     * The input object handed to the trait.
+     *
+     * @var  Input|null
+     */
+    private $input;
+
+    /**
+     * Set the input object the trait should see.
+     *
+     * @param   Input  $input  The input object.
+     *
+     * @return  void
+     */
+    public function setInput(Input $input): void
+    {
+        $this->input = $input;
+    }
+
+    /**
+     * Method to get the application input object.
+     *
+     * @return  Input
+     */
+    public function getInput(): Input
+    {
+        return $this->input ??= new Input([]);
+    }
+}

--- a/Tests/Web/WebClientTest.php
+++ b/Tests/Web/WebClientTest.php
@@ -8,14 +8,14 @@
 namespace Joomla\Application\Tests\Web;
 
 use Joomla\Application\Web\WebClient;
+use PHPUnit\Framework\Attributes\BackupGlobals;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for Joomla\Application\Web\WebClient.
  *
  * @since         1.0.0
- *
- * @backupGlobals enabled
  */
 class WebClientTest extends TestCase
 {
@@ -490,6 +490,7 @@ class WebClientTest extends TestCase
      *
      * @since   1.0.0
      */
+    #[BackupGlobals(true)]
     public function setUp(): void
     {
         parent::setUp();
@@ -512,10 +513,10 @@ class WebClientTest extends TestCase
      *
      * @return  void
      *
-     * @dataProvider getUserAgentData
      * @since        1.0.0
      * @covers       \Joomla\Application\Web\WebClient
      */
+    #[DataProvider('getUserAgentData')]
     public function testDetectBrowser($p, $m, $e, $b, $v, $ua)
     {
         $client = new WebClient($ua);
@@ -553,10 +554,10 @@ class WebClientTest extends TestCase
      *
      * @return  void
      *
-     * @dataProvider getEncodingData
      * @since        1.0.0
      * @covers       \Joomla\Application\Web\WebClient
      */
+    #[DataProvider('getEncodingData')]
     public function testDetectEncoding($ae, $e)
     {
         $client = new WebClient(null, $ae);
@@ -577,10 +578,10 @@ class WebClientTest extends TestCase
      *
      * @return  void
      *
-     * @dataProvider getUserAgentData
      * @since        1.0.0
      * @covers       \Joomla\Application\Web\WebClient
      */
+    #[DataProvider('getUserAgentData')]
     public function testDetectEngine($p, $m, $e, $b, $v, $ua)
     {
         $client = new WebClient($ua);
@@ -597,10 +598,10 @@ class WebClientTest extends TestCase
      *
      * @return  void
      *
-     * @dataProvider getLanguageData
      * @since        1.0.0
      * @covers       \Joomla\Application\Web\WebClient
      */
+    #[DataProvider('getLanguageData')]
     public function testDetectLanguage($al, $l)
     {
         $client = new WebClient(null, null, $al);
@@ -621,10 +622,10 @@ class WebClientTest extends TestCase
      *
      * @return  void
      *
-     * @dataProvider getUserAgentData
      * @since        1.0.0
      * @covers       \Joomla\Application\Web\WebClient
      */
+    #[DataProvider('getUserAgentData')]
     public function testDetectPlatform($p, $m, $e, $b, $v, $ua)
     {
         $client = new WebClient($ua);
@@ -642,10 +643,10 @@ class WebClientTest extends TestCase
      *
      * @return  void
      *
-     * @dataProvider detectRobotData
      * @since        1.0.0
      * @covers       \Joomla\Application\Web\WebClient
      */
+    #[DataProvider('detectRobotData')]
     public function testDetectRobot($userAgent, $expected)
     {
         $client = new WebClient($userAgent);

--- a/Tests/WebApplicationTest.php
+++ b/Tests/WebApplicationTest.php
@@ -12,12 +12,11 @@ use Joomla\Application\WebApplication;
 use Joomla\Input\Input;
 use Joomla\Router\ResolvedRoute;
 use Joomla\Router\RouterInterface;
+use PHPUnit\Framework\Attributes\BackupGlobals;
 use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for Joomla\Application\WebApplication.
- *
- * @backupGlobals enabled
  */
 class WebApplicationTest extends TestCase
 {
@@ -29,6 +28,7 @@ class WebApplicationTest extends TestCase
      * @uses     \Joomla\Application\AbstractWebApplication
      * @uses     \Joomla\Application\Web\WebClient
      */
+    #[BackupGlobals(true)]
     public function testExecute()
     {
         $_SERVER['REQUEST_METHOD'] = 'GET';

--- a/composer.json
+++ b/composer.json
@@ -52,9 +52,9 @@
         "joomla/session": "^4.0",
         "joomla/test": "^4.0",
         "joomla/uri": "^4.0",
-        "phpunit/phpunit": "^10.0",
+        "phpunit/phpunit": "^12.2.7",
         "symfony/phpunit-bridge": "^7.0",
-        "squizlabs/php_codesniffer": "~3.10.2",
+        "squizlabs/php_codesniffer": "^3.13.6",
         "phpstan/phpstan": "^2.1.17",
         "phpstan/phpstan-deprecation-rules": "^2.0.3"
     },


### PR DESCRIPTION
### Summary of Changes
What the title says. The rest of the framework is already on phpunit 12, now the application is as well. Also updating phpcs to not use the vulnerable version anymore.