### PR TITLE
Update squizlabs/php_codesniffer dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
         "joomla/uri": "^3.0",
         "phpunit/phpunit": "^10.0",
         "symfony/phpunit-bridge": "^7.0",
-        "squizlabs/php_codesniffer": "~3.10.2",
+        "squizlabs/php_codesniffer": "~4.0",
         "phpstan/phpstan": "1.12.27",
         "phpstan/phpstan-deprecation-rules": "1.2.1"
     },


### PR DESCRIPTION
This updates squizlabs/php_codesniffer to version 4. This is necessary since versions 3.10 and below have security issues and are not provided anymore by composer.